### PR TITLE
Fix confusion over version tag in .md source files.

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <title>GCAM {{page.current-version}} Documentation: {{page.title}}</title>
+    <title>GCAM {{page.gcam-version}} Documentation: {{page.title}}</title>
 
     <link rel="stylesheet" href="{{site.github.url}}/stylesheets/styles.css">
     <link rel="stylesheet" href="{{site.github.url}}/stylesheets/github-dark.css">
@@ -19,7 +19,7 @@
   <body>
     <div class="wrapper">
       <header>
-        <h1>GCAM {{page.current-version}} Documentation: {{page.title}}</h1>
+        <h1>GCAM {{page.gcam-version}} Documentation: {{page.title}}</h1>
         <p>Documentation for GCAM<br/>
 	  The Global Change Assessment Model</p>
         <p class="view"><a href="https://github.com/JGCRI/gcam-doc">View the Project on GitHub <small>JGCRI/gcam-doc</small></a></p>

--- a/aglu.md
+++ b/aglu.md
@@ -3,7 +3,7 @@ layout: index
 title: Agriculture, Land-Use, and Bioenergy
 prev: energy.html
 next: hector.html
-current-version: v4.3 
+gcam-version: v4.3 
 ---
 
 In GCAM, the model data for the agriculture and land use parts of the model comprises 283 subregions in terms of land use, based on a division of the extant agro-ecological zones (AEZs), which we derived from work performed for the GTAP project (Monfreda et al, 2009), within each of GCAM’s 32 global geo-political regions. Within each of these 283 subregions, land is categorized into approximately a dozen types based on cover and use. Some of these types, such as tundra and desert, are not considered arable. Among arable land types, further divisions are made for lands historically in non-commercial uses such as forests and grasslands as well as commercial forestlands and croplands. Production of approximately twenty crops is currently modeled, with yields of each specific to each of the 283 subregions. The model is designed to allow specification of different options for future crop management for each crop in each subregion.

--- a/choice.md
+++ b/choice.md
@@ -3,7 +3,7 @@ layout: index
 title: Economic Choice in GCAM
 prev: hector.html
 next: en_technologies.html
-current-version: v4.3
+gcam-version: v4.3
 ---
 
 ## Introduction

--- a/en_technologies.md
+++ b/en_technologies.md
@@ -3,7 +3,7 @@ layout: index
 title: Energy Technologies
 prev: choice.html
 next: solver.html
-current-version: v4.3 
+gcam-version: v4.3 
 ---
 
 This page documents the parameters and functional forms found within technologies in GCAM's energy system. In the heirarchy of the information in the XML input and output files, the technology is located at the following level:

--- a/energy.md
+++ b/energy.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM Energy System
 prev: macro-econ.html
 next: aglu.html
-current-version: v4.3 
+gcam-version: v4.3 
 ---
 
 ## Overview

--- a/gcam-build.md
+++ b/gcam-build.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM Build Instructions
 prev: user-guide.html
 next: 
-current-version: v4.3 
+gcam-version: v4.3 
 ---
 
 ## 1.Introduction

--- a/gcam-usa.md
+++ b/gcam-usa.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM-USA
 prev: 
 next: 
-current-version: v4.3 
+gcam-version: v4.3 
 ---
 
 *Under Construction*

--- a/hector.md
+++ b/hector.md
@@ -3,7 +3,7 @@ layout: index
 title: Climate Module – Hector	
 prev: aglu.html
 next: choice.html
-current-version: v4.3
+gcam-version: v4.3
 ---
 
 This section describes the new climate module - Hector - that is available for use in GCAM. MAGICC5.3 (Wiglley, 2008) has traditionally been the only climate module available in GCAM.  In GCAM's recent release, Hector is now the default climate model(Hartin et al., 2015).  Both Hector and MAGICC are reduced-form climate carbon-cycle models. 

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: Global Change Assessment Model (GCAM)
-current-version: v4.3
+gcam-version: v4.3
 ---
 
 The Joint Global Change Research Institute (JGCRI) is the home and

--- a/macro-econ.md
+++ b/macro-econ.md
@@ -3,7 +3,7 @@ layout: index
 title: The GCAM Macro-Economic System
 prev: overview.html
 next: energy.html
-current-version: v4.3 
+gcam-version: v4.3 
 ---
 
 The **Macro-Economic System** component of core GCAM sets the overall scale of economic activity for model simulations. Assumptions about population, and per capital income growth for each of the 32 geopolitical regions determines the Gross Domestic Product (GDP) in each of GCAM's 32 global geo-political regions. At present, the macro-economic systems provide a one-way transfer of information to other GCAM components; the state of other GCAM components does not affect the overall scale of human activities in GCAM (see below for minor exception to this statement). For example, neither the price nor quantity of energy nor the quantity of energy services provided to the economy affect the calculation of the principle model output of the GCAM macro-economic system, Gross Domestic Product (GDP). Similarly, no detail is provided other macro-economic variables such GDP components (consumption, investment, net exports, aggregate capital stock, and so forth) nor social welfare. The development of two-way coupling with other GCAM components is an important focus of present research efforts. 

--- a/overview.md
+++ b/overview.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM Model Overview
 prev: 
 next: macro-econ.html
-current-version: v4.3 
+gcam-version: v4.3 
 ---
 
 ## Introduction

--- a/solver.md
+++ b/solver.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM Solver
 prev: en_technologies.html
 next: user-guide.html
-current-version: v4.3 
+gcam-version: v4.3 
 ---
 
 At each time step, GCAM searches for a vector of prices that cause all

--- a/toc.md
+++ b/toc.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: Table of Contents
-current-version: v4.3
+gcam-version: v4.3
 ---
 ## GCAM Documentation Topics
 

--- a/user-guide.md
+++ b/user-guide.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM User Guide
 prev: solver.html
 next: gcam-build.html
-current-version: v4.3 
+gcam-version: v4.3 
 ---
 
 ## 1.Introduction

--- a/v4.2/aglu.md
+++ b/v4.2/aglu.md
@@ -3,7 +3,7 @@ layout: index
 title: Agriculture, Land-Use, and Bioenergy
 prev: energy.html
 next: hector.html
-current-version: v4.2 
+gcam-version: v4.2 
 ---
 
 In GCAM, the model data for the agriculture and land use parts of the model comprises 283 subregions in terms of land use, based on a division of the extant agro-ecological zones (AEZs), which we derived from work performed for the GTAP project (Monfreda et al, 2009), within each of GCAM’s 32 global geo-political regions. Within each of these 283 subregions, land is categorized into approximately a dozen types based on cover and use. Some of these types, such as tundra and desert, are not considered arable. Among arable land types, further divisions are made for lands historically in non-commercial uses such as forests and grasslands as well as commercial forestlands and croplands. Production of approximately twenty crops is currently modeled, with yields of each specific to each of the 283 subregions. The model is designed to allow specification of different options for future crop management for each crop in each subregion.

--- a/v4.2/choice.md
+++ b/v4.2/choice.md
@@ -3,7 +3,7 @@ layout: index
 title: Economic Choice in GCAM
 prev: hector.html
 next: en_technologies.html
-current-version: v4.2
+gcam-version: v4.2
 ---
 
 ## Introduction

--- a/v4.2/en_technologies.md
+++ b/v4.2/en_technologies.md
@@ -3,7 +3,7 @@ layout: index
 title: Energy Technologies
 prev: choice.html
 next: solver.html
-current-version: v4.2 
+gcam-version: v4.2 
 ---
 
 This page documents the parameters and functional forms found within technologies in GCAM's energy system. In the heirarchy of the information in the XML input and output files, the technology is located at the following level:

--- a/v4.2/energy.md
+++ b/v4.2/energy.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM Energy System
 prev: macro-econ.html
 next: aglu.html
-current-version: v4.2 
+gcam-version: v4.2 
 ---
 
 ## Overview

--- a/v4.2/gcam-build.md
+++ b/v4.2/gcam-build.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM Build Instructions
 prev: user-guide.html
 next: 
-current-version: v4.2 
+gcam-version: v4.2 
 ---
 
 ## 1.Introduction

--- a/v4.2/gcam-usa.md
+++ b/v4.2/gcam-usa.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM-USA
 prev: 
 next: 
-current-version: v4.2 
+gcam-version: v4.2 
 ---
 
 *Under Construction*

--- a/v4.2/hector.md
+++ b/v4.2/hector.md
@@ -3,7 +3,7 @@ layout: index
 title: Climate Module – Hector	
 prev: aglu.html
 next: choice.html
-current-version: v4.2
+gcam-version: v4.2
 ---
 
 This section describes the new climate module - Hector - that is available for use in GCAM. MAGICC5.3 (Wiglley, 2008) has traditionally been the only climate module available in GCAM.  In GCAM's recent release, there is now the option to run Hector (Hartin et al., 2015).  Both Hector and MAGICC are reduced-form climate carbon-cycle models. 

--- a/v4.2/index.md
+++ b/v4.2/index.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: Global Change Assessment Model (GCAM)
-current-version: v4.2
+gcam-version: v4.2
 ---
 
 The Joint Global Change Research Institute (JGCRI) is the home and

--- a/v4.2/macro-econ.md
+++ b/v4.2/macro-econ.md
@@ -3,7 +3,7 @@ layout: index
 title: The GCAM Macro-Economic System
 prev: overview.html
 next: energy.html
-current-version: v4.2 
+gcam-version: v4.2 
 ---
 
 The **Macro-Economic System** component of core GCAM sets the overall scale of economic activity for model simulations. Assumptions about population, and per capital income growth for each of the 32 geopolitical regions determines the Gross Domestic Product (GDP) in each of GCAM's 32 global geo-political regions. At present, the macro-economic systems provide a one-way transfer of information to other GCAM components; the state of other GCAM components does not affect the overall scale of human activities in GCAM (see below for minor exception to this statement). For example, neither the price nor quantity of energy nor the quantity of energy services provided to the economy affect the calculation of the principle model output of the GCAM macro-economic system, Gross Domestic Product (GDP). Similarly, no detail is provided other macro-economic variables such GDP components (consumption, investment, net exports, aggregate capital stock, and so forth) nor social welfare. The development of two-way coupling with other GCAM components is an important focus of present research efforts. 

--- a/v4.2/overview.md
+++ b/v4.2/overview.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM Model Overview
 prev: 
 next: macro-econ.html
-current-version: v4.2 
+gcam-version: v4.2 
 ---
 
 ## Introduction

--- a/v4.2/solver.md
+++ b/v4.2/solver.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM Solver
 prev: en_technologies.html
 next: user-guide.html
-current-version: v4.2 
+gcam-version: v4.2 
 ---
 
 At each time step, GCAM searches for a vector of prices that cause all

--- a/v4.2/toc.md
+++ b/v4.2/toc.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: Table of Contents
-current-version: v4.2
+gcam-version: v4.2
 ---
 ## GCAM Documentation Topics
 

--- a/v4.2/user-guide.md
+++ b/v4.2/user-guide.md
@@ -3,7 +3,7 @@ layout: index
 title: GCAM User Guide
 prev: solver.html
 next: gcam-build.html
-current-version: v4.2 
+gcam-version: v4.2 
 ---
 
 ## 1.Introduction


### PR DESCRIPTION
The tag is now consistently `gcam-version` across all versions.  Previously, some versions were using `gcam-version`, and others were using `current-version`.
