### PR TITLE
Fix site warnings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,3 @@
 timezone: America/New_York
 encoding: utf-8
+github: [metadata]

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="{{site.github.url}}/stylesheets/github-dark.css">
     <link rel="shortcut icon" href="{{site.github.url}}/images/logo.gif">
     <script src="{{site.github.url}}/javascripts/scale.fix.js"></script>
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 
     <!--[if lt IE 9]>


### PR DESCRIPTION
Fix some warnings we were seeing with the gcam-doc site.  This ensures things are rendering properly locally as well.