### PR TITLE
Move policy set-up information to policy page.

### DIFF
--- a/choice.md
+++ b/choice.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: Economic Choice in GCAM
-prev: hector.html
+prev: emissions.html
 next: en_technologies.html
 gcam-version: v5.1
 ---

--- a/emissions.md
+++ b/emissions.md
@@ -17,23 +17,24 @@ Future emissions are determined by the evolution of drivers (such as energy cons
 Table Of Contents
 
 * [CO<sub>2</sub> Emissions](#co2-emissions)
-* [non-CO<sub>2</sub> GHG Emissions](#non-co2-ghg-emissions)
+* [CO<sub>2</sub> Emissions From Land-Use/Land-Use Change (LULUC)](#co2-luc-emissions)
 * [Non-CO<sub>2</sub> Emissions Overview](#non-co2-overview)
-* [non-CO<sub>2</sub> GHG Emissions](#non-co2-ghg-emissions)
+* [Non-CO<sub>2</sub> GHG Emissions](#non-co2-ghg-emissions)
+* [Air Pollutant Emissions](#air-pollutant-emissions)
 * [Advanced Non-CO<sub>2</sub> User Options](#user-options)
 
 ## <a name="co2-emissions">CO<sub>2</sub> Emissions</a>
 
-GCAM endogenously estimates CO<sub>2</sub> fossil-fuel related emissions based on fossil fuel consumption and global emission factors by fuel (oil, unconventional oil, natural gas, and coal). These emission factors are consistent with global emissions by fuel from the CDIAC global inventory ([CDIAC 2017](emissions.html#cdiac2017)). 
+GCAM endogenously estimates CO<sub>2</sub> fossil-fuel related emissions based on fossil fuel consumption and global emission factors by fuel (oil, unconventional oil, natural gas, and coal). These emission factors are consistent with global emissions by fuel from the CDIAC global inventory ([CDIAC 2017](#cdiac2017)). 
 
 GCAM can be considered as a process model for CO<sub>2</sub> emissions and reductions. CO<sub>2</sub> emissions change over time as fuel consumption in GCAM endogenously changes. Application of Carbon Capture and Storage (CCS) is explicitly considered as separate technological options for a number of processes, such as electricity generation and fertilizer manufacturing. The GCAM, in effect, produces a Marginal Abatement Curve for CO<sub>2</sub> as a carbon-price is applied within the model.
 
-CO<sub>2</sub> emissions from limestone used in cement production are also estimated. Limestone consumption has one global emissions factor, however, each region’s IO coefficient (limestone / cement) is calibrated to return CDIAC estimates ([CDIAC 2017](emissions.html#cdiac2017)). (CO<sub>2</sub> from fuel consumed in producing limestone is estimated in the same manner as other fuel consumption.)
+CO<sub>2</sub> emissions from limestone used in cement production are also estimated. Limestone consumption has one global emissions factor, however, each region’s IO coefficient (limestone / cement) is calibrated to return CDIAC estimates ([CDIAC 2017](#cdiac2017)). (CO<sub>2</sub> from fuel consumed in producing limestone is estimated in the same manner as other fuel consumption.)
 
 CO<sub>2</sub> emissions from gas flaring are not currently included in GCAM.
 
-### CO<sub>2</sub> Emissions From Land-Use/Land-Use Change (LULUC)
-
+### <a name="co2-luc-emissions">CO<sub>2</sub> Emissions From Land-Use/Land-Use Change (LULUC)</a>
+ 
 Land-Use Change emissions are tracked separately. In general, emissions are estimated as:
 
 $$
@@ -44,22 +45,22 @@ Where E indicates carbon emissions, S indicates carbon stocks, A indicates land 
 
 When land is converted to forests, the vegetation carbon content of that new forest land exponentially approaches an exogenously-specified, region-dependent value in order to represent the finite time required for forests to grow, as shown in the figure below.
 
-![Figure 1](gcam-figs/forest_carbon_evolution.png)
-Timescales for forest regrowth in GCAM.
+![Figure 1](gcam-figs/forest_carbon_evolution.png)<br/>
+Figure 1: Timescales for forest regrowth in GCAM.
 {: .fig}
 
 Changes in the carbon content of soils due to land-use change also exponentially approach an equilibrium value using a region-dependent timescale. This represents the timescales for carbon pool changes in soils.
 
-##<a name="non-co2-overview"> Non-CO<sub>2</sub> Emissions Overview</a>
+##<a name="non-co2-overview">Non-CO<sub>2</sub> Emissions Overview</a>
 
 We summarize here some general points common to non-CO<sub>2</sub> emissions in GCAM
 
 Non-CO<sub>2</sub> emissions, both GHGs & air pollutants, originate from many sources and can be controlled using multiple abatement technologies.
-Modeling non-CO<sub>2</sub> abatement at the process level would require too much detail for the scales at which GCAM operates. We, therefore, use parameterized functions for future emissions controls (for air pollutants) and Marginal Abatement Cost (MAC) curves (for GHGs) to change emission factors over time. The emissions controls, which reduce emissions factors as a function of per-capita GDP in each region and time period, are based on the general understanding that pollutant control technologies are deployed as incomes rise (e.g., [Smith et al. 2005](emissions.html#smith2005), although the functional form used in GCAM 5 is different than that in this reference). The MAC curves for GHGs are mapped directly to GCAM's technologies from the EPA's 2013 report on non-CO<sub>2</sub> greenhouse gas mitigation ([EPA 2013](emissions.html#epa2013)).
+Modeling non-CO<sub>2</sub> abatement at the process level would require too much detail for the scales at which GCAM operates. We, therefore, use parameterized functions for future emissions controls (for air pollutants) and Marginal Abatement Cost (MAC) curves (for GHGs) to change emission factors over time. The emissions controls, which reduce emissions factors as a function of per-capita GDP in each region and time period, are based on the general understanding that pollutant control technologies are deployed as incomes rise (e.g., [Smith et al. 2005](#smith2005), although the functional form used in GCAM 5 is different than that in this reference). The MAC curves for GHGs are mapped directly to GCAM's technologies from the EPA's 2013 report on non-CO<sub>2</sub> greenhouse gas mitigation ([EPA 2013](#epa2013)).
 
 Note that technology shifts still play a role, since emission factors can differ between technologies.
 
-Most base-year non-CO<sub>2</sub> emissions are calibrated to the EDGAR 4.2 emissions inventories ([EDGAR 2011](emissions.html#edgar2011)), with USA fuel-level emissions detail from the US EPA's National Emissions Inventory ([EPA 2011](emissions.html#epa2011)) used to disaggregate sectoral totals to specific fuel types. Black carbon (BC) and organic carbon (OC) emissions are calibrated using the RCP (CMIP5) inventories ([Lamarque et al. 2010](emissions.html#lamarque2010)). Additional information on fluorinated gases is from Guus Velders.
+Most base-year non-CO<sub>2</sub> emissions are calibrated to the EDGAR 4.2 emissions inventories ([EDGAR 2011](#edgar2011)), with USA fuel-level emissions detail from the US EPA's National Emissions Inventory ([EPA 2011](#epa2011)) used to disaggregate sectoral totals to specific fuel types. Black carbon (BC) and organic carbon (OC) emissions are calibrated using the RCP (CMIP5) inventories ([Lamarque et al. 2010](#lamarque2010)). Additional information on fluorinated gases is from Guus Velders.
 
 ####  Energy System Drivers
 * Emissions in the energy system can be driven by input (e.g., fuel consumed by a particular technology) or output (e.g., fuel or service produced by a particular technology).
@@ -94,7 +95,7 @@ where:
 | MAC | Marginal Abatement Cost Curve |
 | Eprice | Emissions Price |
 
-Non-CO<sub>2</sub> GHG emissions are proportional to the activity except for any reductions in emission intensity due to the MAC curve. As noted above, the MAC curves are assigned to a wide variety of technologies, mapped directly from [EPA 2013](emissions.html#epa2013). Under a carbon policy, emissions are reduced by an amount determined by the MAC curve.
+Non-CO<sub>2</sub> GHG emissions are proportional to the activity except for any reductions in emission intensity due to the MAC curve. As noted above, the MAC curves are assigned to a wide variety of technologies, mapped directly from [EPA 2013](#epa2013). Under a carbon policy, emissions are reduced by an amount determined by the MAC curve.
 
 The default set-up is that MAC curves use the scenario's carbon price (if any). The non-CO<sub>2</sub> GHG MACs are an exogenous input, and are read in as the percent of emissions abated as a function of the emissions prices. Note that they are read in with explicit cost points (i.e., piece-wise linear form), with no underlying equation describing the percentage of abatement as a function of the carbon price.
 
@@ -124,7 +125,7 @@ $$
 
 where *pcGDP* stands for the per-capita GDP, and *steepness* is an exogenous constant, specific to each technology and pollutant species, that governs the degree to which changes in per-capita GDP will be translated to emissions controls. The purpose here is to capture the general global trend of increasing pollutant controls over time, but does not capture regional and technological heterogeneity.
 
-Note that the GCAM implementation of the SSP scenarios used a different approach, incorporating region-, sector-, and fuel-specific pollutant emission factor pathways ([Calvin et al. 2017](emissions.html#calvin2016), [Rao et al. 2017](emissions.html#rao2016)). 
+Note that the GCAM implementation of the SSP scenarios used a different approach, incorporating region-, sector-, and fuel-specific pollutant emission factor pathways ([Calvin et al. 2017](#calvin2017), [Rao et al. 2017](#rao2017)). 
 
 ## <a name="user-options">Advanced Non-CO<sub>2</sub> User Options</a>
 
@@ -153,13 +154,13 @@ allow-ef-increase | (optional) Allow emission factors to increase from their sta
 
 <a name="calvin2017">[Calvin et al. 2017]</a> Calvin, K., Bond-Lamberty, B., Clarke, L., et al. 2017. The SSP4: a world of deepening inequality. *Global Environmental Change* 42: 284–296. doi:10.1016/j.gloenvcha.2016.06.010. [Link](https://www.sciencedirect.com/science/article/pii/S095937801630084X)
 
-<a name="cdiac2017 ">[CDIAC 2017]</a> Boden, T., and Andres, B. 2017, *National CO2 Emissions from Fossil-Fuel Burning, Cement Manufacture, and Gas Flaring: 1751-2014*, Carbon Dioxide Information Analysis Center, Oak Ridge National Laboratory. [Link](http://cdiac.ess-dive.lbl.gov/ftp/ndp030/nation.1751_2014.ems)
+<a name="cdiac2017">[CDIAC 2017]</a> Boden, T., and Andres, B. 2017, *National CO2 Emissions from Fossil-Fuel Burning, Cement Manufacture, and Gas Flaring: 1751-2014*, Carbon Dioxide Information Analysis Center, Oak Ridge National Laboratory. [Link](http://cdiac.ess-dive.lbl.gov/ftp/ndp030/nation.1751_2014.ems)
 
-<a name="edgar2011 ">[EDGAR 2011]</a> Joint Research Centre. 2011. *EDGAR - Emissions Database for Global Atmospheric Research: Global Emissions EDGAR v4.2*. doi:10.2904/EDGARv4.2. [Link](http://edgar.jrc.ec.europa.eu/overview.php?v=42)
+<a name="edgar2011">[EDGAR 2011]</a> Joint Research Centre. 2011. *EDGAR - Emissions Database for Global Atmospheric Research: Global Emissions EDGAR v4.2*. doi:10.2904/EDGARv4.2. [Link](http://edgar.jrc.ec.europa.eu/overview.php?v=42)
 
-<a name="epa2011 ">[EPA 2011]</a> US EPA, 2011, *2011 National Emissions Inventory (NEI) Data*. United States Environmental Protection Agency, Office of Air Quality Planning and Standards. [Link](https://www.epa.gov/air-emissions-inventories/2011-national-emissions-inventory-nei-data)
+<a name="epa2011">[EPA 2011]</a> US EPA, 2011, *2011 National Emissions Inventory (NEI) Data*. United States Environmental Protection Agency, Office of Air Quality Planning and Standards. [Link](https://www.epa.gov/air-emissions-inventories/2011-national-emissions-inventory-nei-data)
 
-<a name="epa2013 ">[EPA 2013]</a> US EPA, 2013, *Global Mitigation of Non-CO<sub>2</sub> Greenhouse Gases: 2010-2030*. EPA-430-R-13-011, United States Environmental Protection Agency, Office of Atmospheric Programs. [Link](https://www.epa.gov/sites/production/files/2016-06/documents/mac_report_2013.pdf)
+<a name="epa2013">[EPA 2013]</a> US EPA, 2013, *Global Mitigation of Non-CO<sub>2</sub> Greenhouse Gases: 2010-2030*. EPA-430-R-13-011, United States Environmental Protection Agency, Office of Atmospheric Programs. [Link](https://www.epa.gov/sites/production/files/2016-06/documents/mac_report_2013.pdf)
 
 <a name="lamarque2010">[Lamarque et al. 2010]</a> Lamarque, J.F., Bond, T. C., Eyring, V., et al. 2010. Historical (1850-2000) gridded anthropogenic and biomass burning emissions of reactive gases and aerosols: methodology and application, *Atmospheric Chemistry and Physics* 10(15): 7017–7039. doi:10.5194/acp-10-7017-2010. [Link](https://www.atmos-chem-phys.net/10/7017/2010/acp-10-7017-2010.html)
 

--- a/emissions.md
+++ b/emissions.md
@@ -51,7 +51,7 @@ Figure 1: Timescales for forest regrowth in GCAM.
 
 Changes in the carbon content of soils due to land-use change also exponentially approach an equilibrium value using a region-dependent timescale. This represents the timescales for carbon pool changes in soils.
 
-##<a name="non-co2-overview">Non-CO<sub>2</sub> Emissions Overview</a>
+## <a name="non-co2-overview">Non-CO<sub>2</sub> Emissions Overview</a>
 
 We summarize here some general points common to non-CO<sub>2</sub> emissions in GCAM
 

--- a/emissions.md
+++ b/emissions.md
@@ -68,7 +68,7 @@ Most base-year non-CO<sub>2</sub> emissions are calibrated to the EDGAR 4.2 emis
 
 ####  Agriculture and Land-Use Drivers
 * Emissions in the agriculture and land use system can be driven by output (e.g., for crop production) or land area (e.g., for forest fires).
-* Emissions are modeled at the level of agricultural technologies: region, water basin, crop type, and irrigation and management level. Note however that the underlying inventory data is far coarses, typically only available by sector and country. 
+* Emissions are modeled at the level of agricultural technologies: region, water basin, crop type, and irrigation and management level. Note however that the underlying inventory data is far coarser, typically only available by sector and country. 
 
 ####  Naming Conventions
 There are some naming conventions for a few emission species/sectors within GCAM that are useful to note.
@@ -128,46 +128,16 @@ Note that the GCAM implementation of the SSP scenarios used a different approach
 
 ## <a name="user-options">Advanced Non-CO<sub>2</sub> User Options</a>
 
-### Linked Emission Markets
-Emissions prices of different GHGs can be linked together for a multi-gas policy using the linked-ghg-policy object. For example, in the default [linked_ghg_policy.xml](https://github.com/JGCRI/gcam-core/blob/master/input/policy/linked_ghg_policy.xml) file in the GCAM release, all non-CO<sub>2</sub> GHGs are linked to the market for CO<sub>2</sub>. 
 
-The parameter price-adjust is used to convert prices (e.g., 100 year GWPs in the default set-up) and demand-adjust is used to convert demand units (e.g., to common units of carbon equivalents).
-These can be changed by year if desired.
+### Markets
 
-Setting price-adjust to zero means that there is no economic feedback for the price of this GHG. MAC curves, however, will still operate under the default set-up (whereby MAC curves are driven by CO<sub>2</sub> prices). This can be changed separately for energy/industrial/urban CH4, agricultural CH4 (CH4\_AGR), and CH4 from agricultural waste burning (CH4\_AWB), LUC CO<sub>2</sub> emissions (e.g. CO2_LUC).
+For information on using markets for non-CO2 emissions see the [markets For non-CO<sub>2</sub>](./policies.html#non-co2-markets) section of the polices page.
 
-Note that you must first create a policy by reading in a <ghgpolicy> object (by reading an an XML with this object first, see the various policy files in the GCAM release) and then you can define how this links to any emissions (through <linked-ghg-policy> objects).
-
-This flexibility allows CO<sub>2</sub>-only, CO<sub>2</sub>-equivalent, or non-CO<sub>2</sub> markets/constraints for various “baskets” of emissions as needed.
-
-Note that the GCAM default set-up includes economic feedbacks for methane and nitrous oxide. This is an idealized assumption, but might not happen in real-world policies. For example, in many current systems agricultural emissions are offsets only – e.g., they get paid to reduce emissions, but are not charged for any remaining emissions. (So to simulate this type of policy, price-adjust would be set to zero).
-
-### Markets For non-CO<sub>2</sub> Emission Species
-
-Markets can be set for any emission species. (e.g., CH4-only market, NOx market, etc.)
-
-Note that it generally does not make sense to set up an emissions market unless the model has a direct way to reduce emissions! (e.g. you’ve added relevant MAC curves.) For example, in [Shi et al. (2017)](energy.html#shi2017) US electricity sector SO<sub>2</sub> and NO<sub>x</sub> markets were used to represent current policies that cap emissions in certain states. MAC curves for existing power plants were added to allow emissions to change in response to market prices.
-
-xml inputs within the MAC curve that will likely need to be used to set-up new markets are:
-
-XML Tag | Description
------------- | -------------
-market-name | Name of market from which the price used by the MAC curve will be obtained (default = "CO2")
-mac-price-conversion | Value to multiply market price by to convert to unit expected by the MAC curve (for example, converting from $/tC to $/tCO2eq) (default  = 1)
-Note | mac-price-conversion can also be set to -1, which is a flag to turn off all use of the MAC curve. This is useful for sensitivity studies.
-
-One additional MAC-curve option to note is:
-
-| | |
------------- | -------------
-zero-cost-phase-in-time | Number of years over which to phase-in "below-zero" MAC curve reductions (default = 25 years)
-
-
-### Other Non-CO<sub>2</sub> Emission Options
+### Additional Non-CO<sub>2</sub> Emission Options
 
 Emission objects can be added/changed via user input in any time period. New parameters (such as emission factors) overwrite any previous values. Note that emission control objects will be copied forward. For vintaged technologies (e.g. electric generation, road transport), any new emission object will be applied to new vintages. Old vintages will retain the previously read-in emission characteristics.
 
-This also means that GHG objects can be removed after a given year by reading in a blank GHG object for that gas.
+This also means that GHG objects can be removed or overwritten after a given year by reading in a new GHG object for that gas. This also applies to GHG control objects. Reading in a new control object, for example, in 2020 for an electric generation technology will negate the effect of a previously read in control object of the same name for that vintage and future vintages. This can, for example, represent a transition from some emissions control regime applied to older vintages to a regime defined by new source performance standards. 
 
 In addition to the GDP control object, a linear-control object is also available that allows a user to specify that an emission factor will linearly change over time to a user-defined value over a specified time period. The parameters controlling the linear-control object are:
 
@@ -194,7 +164,5 @@ allow-ef-increase | (optional) Allow emission factors to increase from their sta
 <a name="lamarque2010">[Lamarque et al. 2010]</a> Lamarque, J.F., Bond, T. C., Eyring, V., et al. 2010. Historical (1850-2000) gridded anthropogenic and biomass burning emissions of reactive gases and aerosols: methodology and application, *Atmospheric Chemistry and Physics* 10(15): 7017–7039. doi:10.5194/acp-10-7017-2010. [Link](https://www.atmos-chem-phys.net/10/7017/2010/acp-10-7017-2010.html)
 
 <a name="rao2017">[Rao et al. 2017]</a> Rao, S., Klimont, Z., Smith, S., et al. 2017. Future air pollution int he Shared Socio-economic Pathways. *Global Environmental Change* 42: 246–358. doi:10.1016/j.gloenvcha.2016.05.012. [Link](https://www.sciencedirect.com/science/article/pii/S0959378016300723)
-
-<a name="shi2017">[Shi et al. 2017]</a> Shi W, Ou Y, Smith S J, Ledna C M, Nolte C G, Loughlin D H 2017. "Projecting state-level air pollutant emissions using an integrated assessment model: GCAM-USA" *Applied Energy* 208 511–521. doi: 10.1016/j.apenergy.2017.09.122. [Link](https://www.sciencedirect.com/science/article/pii/S0306261917314125)
 
 <a name="smith2005">[Smith et al. 2005]</a> Smith, S.J., Pitcher, H., and Wigley, T. 2005. "Future Sulfur Dioxide Emissions" *Climatic Change* 3: 267-318. doi: 10.1007/s10584-005-6887-y. [Link](https://link.springer.com/article/10.1007/s10584-005-6887-y)

--- a/emissions.md
+++ b/emissions.md
@@ -1,8 +1,8 @@
 ---
 layout: index
 title: GCAM Emissions
-prev: ssp.html
-next: aglu.html
+prev: hector.html
+next: choice.html
 gcam-version: v5.1
 ---
 

--- a/hector.md
+++ b/hector.md
@@ -1,8 +1,8 @@
-﻿---
+---
 layout: index
 title: Earth System Module – Hector v2.0	
 prev: water.html
-next: choice.html
+next: emissions.html
 gcam-version: v5.1
 ---
 

--- a/index.md
+++ b/index.md
@@ -13,6 +13,7 @@ An overview of GCAM is available at [GCAM Model Overview](overview.html). The fi
 * [Agriculture, Land-Use, and Bioenergy](aglu.html)
 * [Water](water.html)
 * [Climate](hector.html) 
+* [Emissions](choice.html)
 * [Economic Choice](choice.html)
 * [Solution and Computation](solver.html)
 * [Trade](trade.html)

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ An overview of GCAM is available at [GCAM Model Overview](overview.html). The fi
 * [Agriculture, Land-Use, and Bioenergy](aglu.html)
 * [Water](water.html)
 * [Climate](hector.html) 
-* [Emissions](choice.html)
+* [Emissions](emissions.html)
 * [Economic Choice](choice.html)
 * [Solution and Computation](solver.html)
 * [Trade](trade.html)
@@ -38,3 +38,4 @@ GCAM is under continuing development. Informatiion on how this version of GCAM d
 * [GCAM-4.2](v4.2/toc.html)
 * [GCAM-4.3](v4.3/toc.html)
 * [GCAM-4.4](v4.4/toc.html)
+

--- a/policies.md
+++ b/policies.md
@@ -54,11 +54,6 @@ XML Tag | Description
 market-name | Name of market from which the price used by the MAC curve will be obtained (default = "CO2")
 mac-price-conversion | Value to multiply market price by to convert to unit expected by the MAC curve (for example, converting from $/tC to $/tCO2eq) (default  = 1)
 Note | mac-price-conversion can also be set to -1, which is a flag to turn off all use of the MAC curve. This is useful for sensitivity studies.
-
-One additional MAC-curve option to note is:
-
-| | |
------------- | -------------
 zero-cost-phase-in-time | Number of years over which to phase-in "below-zero" MAC curve reductions (default = 25 years)
 
 ## <a name="energy-production-policies"> Energy Production Policies </a>

--- a/policies.md
+++ b/policies.md
@@ -7,13 +7,27 @@ gcam-version: v5.1
 One of GCAM's uses is to explore the implications of different future policies. There are a number of types of policies that can be easily modeled in GCAM. The most common of these are discussed below.
 
 ## Emissions-Related Policies
-There are three main policy approaches that can be applied in GCAM to reduce emissions of CO2 or other greenhouse gases: carbon or GHG prices, emissions constraints, or climate constraints. In all cases, GCAM implements the policy approach by placing a price on emissions. This price then filters down through all the systems in GCAM and alters production and demand. For exammple,a price on carbon would put a cost on emitting fossil fuels. This cost would then influence the cost of producing electricity from fossil-fired power plants that emit CO2, which would then influence their relative cost compared to other electricity generating technologies and increase the price of electricity. The increased price of electricity would then make its way to consumers that use electrcity, decreasing its competitiveness relative to other fuels and leading to a decrease in electricity demand. The three policy approaches are described below.
+There are three main policy approaches that can be applied in GCAM to reduce emissions of CO2 or other greenhouse gases: carbon or GHG prices, emissions constraints, or climate constraints. In all cases, GCAM implements the policy approach by placing a price on emissions. This price then filters down through all the systems in GCAM and alters production and demand. For example, a price on carbon would put a cost on emitting fossil fuels. This cost would then influence the cost of producing electricity from fossil-fired power plants that emit CO2, which would then influence their relative cost compared to other electricity generating technologies and increase the price of electricity. The increased price of electricity would then make its way to consumers that use electricity, decreasing its competitiveness relative to other fuels and leading to a decrease in electricity demand. The three policy approaches are described below.
 
 * Carbon or GHG prices: GCAM users can directly specify the price of carbon or GHGs. Given a carbon price, the resulting emissions will vary depending on other scenario drivers, such as population, GDP, resources, and technology.
 
 * Emissions constraints. GCAM users can specify the total amount of emissions (CO2 or GHG) as well. GCAM will then calculate the price of carbon needed to reach the constraint in each period of the constraint.
 
 * Climate constraints: GCAM users can specify a climate variable (e.g., concentration or radiative forcing) target for a particular year. Users determine whether that target can be exceeded prior to the target year. GCAM will adjust carbon prices in order to find the least cost path to reaching the target. (Note that this type of policy increases model run time significantly.)
+
+### Linked Emission Markets
+Emissions prices of different GHGs can be linked together for a multi-gas policy using the linked-ghg-policy object. For example, in the default [linked_ghg_policy.xml](https://github.com/JGCRI/gcam-core/blob/master/input/policy/linked_ghg_policy.xml) file in the GCAM release, all non-CO<sub>2</sub> GHGs are linked to the market for CO<sub>2</sub>. 
+
+The parameter price-adjust is used to convert prices (e.g., 100 year GWPs in the default set-up) and demand-adjust is used to convert demand units (e.g., to common units of carbon equivalents).
+These can be changed by year if desired.
+
+Setting price-adjust to zero means that there is no economic feedback for the price of this GHG. MAC curves, however, will still operate under the default set-up (whereby MAC curves are driven by CO<sub>2</sub> prices). This can be changed separately for energy/industrial/urban CH4, agricultural CH4 (CH4\_AGR), and CH4 from agricultural waste burning (CH4\_AWB), LUC CO<sub>2</sub> emissions (e.g. CO2_LUC).
+
+Note that you must first create a policy by reading in a <ghgpolicy> object (by reading an an XML with this object first, see the various policy files in the GCAM release) and then you can define how this links to any emissions (through <linked-ghg-policy> objects).
+
+This flexibility allows CO<sub>2</sub>-only, CO<sub>2</sub>-equivalent, or non-CO<sub>2</sub> markets/constraints for various “baskets” of emissions as needed.
+
+Note that the GCAM default set-up includes economic feedbacks for methane and nitrous oxide. This is an idealized assumption, but might not happen in real-world policies. For example, in many current systems agricultural emissions are offsets only – e.g., they get paid to reduce emissions, but are not charged for any remaining emissions. (So to simulate this type of policy, price-adjust would be set to zero).
 
 ## Energy Production Policies
 There are times in which users would like to explore the implications of a constraint on production or a minimum production requirement. This capability allows GCAM users to model policies such as renewable portfolio standards and biofuels standards. Across sectors, these constraints must be applied as quantity constraints, but they can be applied as share constraints within individual sectors (e.g., fraction of electricity that comes from solar power). In implementing these policies, users This can either be a lower bound or upper bound. The model will solve for the tax (upper bound) or subsidy (lower bound) required to reach the given constraint.
@@ -29,30 +43,55 @@ There are a number of ways that policies can be applied directly to influence th
 
 ## Calculating Emissions Policy Costs
 
-The cost of emissions mitigation is a concept that is not uniquely defined. A wide range of measures are used in the literature. These include, the price of carbon (or as appropriate given the policy) needed to achieve a desired emission mitigation goal, reduction in Gross Domestic Product (GDP), consumption loss, deadweight loss, and equivalent variation. Beyond that the concept of net cost, which includes the benefits of emissions mitigation as well as the resource cost of emissions reduction and the social cost of carbon are also encountered. GCAM makes no attempt to calculate the benefits.
+The cost of GHG emissions mitigation is a concept that is not uniquely defined. A wide range of measures are used in the literature. These include, the price of carbon (or as appropriate given the policy) needed to achieve a desired emission mitigation goal, reduction in Gross Domestic Product (GDP), consumption loss, deadweight loss, and equivalent variation. Beyond that the concept of net cost, which includes the benefits of emissions mitigation as well as the resource cost of emissions reduction and the social cost of carbon are also encountered. GCAM makes no attempt to calculate the benefits.
 
-In addition to identifying policy prices as one measure of cost, GCAM employs the “deadweight loss” approach to measuring welfare loss from emissions mitigation efforts. GCAM employs the deadweight loss approach for several reasons. First, the deadweight loss approach is numerically straight forward to calculate in GCAM. Second, the deadweight loss approach provides a computationally tractable method to measuring the change in welfare, though it is only an approximation. In principle the equivalent variation is the right approach to measure an individual’s loss in welfare. Equivalent variation measures the minimum amount of income that would be needed to leave consumers just as happy with the new price (e.g. carbon tax) as without. However, its calculation requires either knowledge of all of society’s individual preference functions or the existence of a well-ordered set of social preferences, a requirement that Arrow (1950) demonstrated to be impossible under ordinary circumstances. Third, the deadweight loss approach takes advantage of GCAM’s detailed technological characterization.
+In addition to identifying policy prices as one measure of cost, GCAM employs the “deadweight loss” approach to measuring welfare loss from emissions mitigation efforts. GCAM employs the deadweight loss approach for several reasons. First, the deadweight loss approach is numerically straight forward to calculate in GCAM. Second, the deadweight loss approach provides a computationally tractable method to measuring the change in welfare, though it is only an approximation. In principle the equivalent variation is the right approach to measure an individual’s loss in welfare. Equivalent variation measures the minimum amount of income that would be needed to leave consumers just as happy with the new price (e.g. carbon tax) as without. However, its calculation requires either knowledge of all of society’s individual preference functions or the existence of a well-ordered set of social preferences, a requirement that [Arrow (1950)](policies.html#Arrow1950) demonstrated to be impossible under ordinary circumstances. Third, the deadweight loss approach takes advantage of GCAM’s detailed technological characterization.
 
-A detailed description of the method used in GCAM is documented in Bradley, et al. (2001). In general, the approach is as follows. GCAM calculates the cost of emissions mitigation at each GCAM time step. For example in the figure below, the cost of moving from a reference path without a carbon tax (blue) to the emissions path with a carbon tax (green) in period T can be calculated simply. Successive scenarios with fixed carbon taxes in period T are run. The associated emissions are recorded for each carbon tax. The cost is calculated as the area of the purple triangle, which is the integral of each emissions mitigation step weighted by the carbon tax that was required to deliver the reduction. The final ton of carbon emissions is the most expensive ton, because it is assumed that for a carbon tax, emissions mitigation occurs with the least expensive tons being reduced first. The final ton of carbon is simply the carbon tax rate itself. The tax revenue can be calculated as the tax rate times the remaining emissions, shown in red below.
+A detailed description of the method used in GCAM is documented in [Bradley et al. (1991)](policies.html#Bradley1991). In general, the approach is as follows. GCAM calculates the cost of emissions mitigation at each GCAM time step. For example in the figure below, the cost of moving from a reference path without a carbon tax (blue) to the emissions path with a carbon tax (green) in period T can be calculated simply. Successive scenarios with fixed carbon taxes in period T are run. The associated emissions are recorded for each carbon tax. The cost is calculated as the area of the purple triangle, which is the integral of each emissions mitigation step weighted by the carbon tax that was required to deliver the reduction. The final ton of carbon emissions is the most expensive ton, because it is assumed that for a carbon tax, emissions mitigation occurs with the least expensive tons being reduced first. The final ton of carbon is simply the carbon tax rate itself. The tax revenue can be calculated as the tax rate times the remaining emissions, shown in red below.
 
 <img src="gcam-figs/policy cost.png" width="750" height="300" />
 
-As discussed in Bradley, et al. (2001) and demonstrated in Calvin, et al. (2014), the approach can be used to calculate costs for a wide range of heterogeneous non-price policies. While conceptually similar to the simple approach above, the other is tedious. Similarly, the deadweight loss approach can be used to calculate the cost of policies other than carbon taxes. It is completely general (Mankiw and Hakes, 2012).
+As discussed in [Bradley et al. (1991)](policies.html#Bradley1991) and demonstrated in [Calvin et al. (2014)](policies.html#Calvin2014), the approach can be used to calculate costs for a wide range of heterogeneous non-price policies. While conceptually similar to the simple approach above, the other is tedious. Similarly, the deadweight loss approach can be used to calculate the cost of policies other than carbon taxes. It is completely general [Mankiw & Hakes (2012)](policies.html#Mankiw2012).
+
 
 The approach is employed at each GCAM time step. Costs occurring between time steps is inferred by interpolation. Costs over time can be summed. Costs can be summed with or without discounting. But, the GCAM user needs to be aware of the implications of whatever approach is employed.
 
 The deadweight loss approach is not without its limitations. While the numerical calculation is simple for a uniform carbon tax (or a cap-and-trade regime), more complex policies are more tedious to represent. Second, there is no link back to the macro-economy. Changes of the magnitude associated with stringent climate policies will have macro-economic consequences. Those consequence will, in turn affect the scale of economic activity. Third, there is no way to calculate the effects of alternative uses of tax revenue or carbon permit allocations.
 
+## <a name="non-co2-markets"> Markets For non-CO<sub>2</sub> Emission Species</a>
+
+Markets in GCAM can be set for any emission species. (e.g., CH4-only market, NOx market, etc.)
+
+Note that it generally does not make sense to set up an emissions market unless the model has a direct way to reduce emissions! (e.g. you’ve added relevant MAC curves.) For example, in [Shi et al. (2017)](policies.html#shi2017) US electricity sector SO<sub>2</sub> and NO<sub>x</sub> markets were used to represent current policies that cap emissions in certain states. MAC curves for existing power plants were added to allow emissions to change in response to market prices. 
+
+xml inputs within the MAC curve that will be needed to set-up new markets are:
+
+XML Tag | Description
+------------ | -------------
+market-name | Name of market from which the price used by the MAC curve will be obtained (default = "CO2")
+mac-price-conversion | Value to multiply market price by to convert to unit expected by the MAC curve (for example, converting from $/tC to $/tCO2eq) (default  = 1)
+Note | mac-price-conversion can also be set to -1, which is a flag to turn off all use of the MAC curve. This is useful for sensitivity studies.
+
+One additional MAC-curve option to note is:
+
+| | |
+------------ | -------------
+zero-cost-phase-in-time | Number of years over which to phase-in "below-zero" MAC curve reductions (default = 25 years)
+
 ## References
+<a name="Arrow1950">[Arrow 1950]</a> Arrow, Kenneth J. (1950). "A Difficulty in the Concept of Social Welfare" (PDF). Journal of Political Economy. 58 (4): 328–346. doi:10.1086/256963.
+[Link](http://dx.doi.org/10.1086/256963)
 
-Arrow, Kenneth J. (1950). "A Difficulty in the Concept of Social Welfare" (PDF). Journal of Political Economy. 58 (4): 328–346. doi:10.1086/256963.
+<a name="Bhattacharya2001">[Bhattacharya 2001]</a> Bhattacharya, Jay. (2001). Three measures of the change in welfare.
+[Link](https://web.stanford.edu/~jay/micro_class/lecture8.pdf)
 
-Bhattacharya, Jay. (2001). Three measures of the change in welfare. https://web.stanford.edu/~jay/micro_class/lecture8.pdf
+<a name="Bradley1991">[Bradley et al. 1991]</a> Bradley, Richard A., Edward C. Watts, and Edward R. Williams. Limiting net greenhouse gas emissions in the United States. No. DOE/PE-0101-Vol. 2. USDOE Office of Policy, Planning and Analysis, Washington, DC (United States). Office of Environmental Analysis, 1991.
+[Link](https://www.osti.gov/servlets/purl/5775139)
 
-Bradley, Richard A., Edward C. Watts, and Edward R. Williams. Limiting net greenhouse gas emissions in the United States. No. DOE/PE-0101-Vol. 2. USDOE Office of Policy, Planning and Analysis, Washington, DC (United States). Office of Environmental Analysis, 1991.
+<a name="Calvin2014">[Calvin et al. 2014]</a> Calvin, Katherine, Jae Edmonds, Bjorn Bakken, Marshall Wise, Son H. Kim, Patrick Luckow, Pralit Patel, Ingeborg Graabak.  (2014). The EU20-20-20 energy policy as a model for global climate mitigation.  Climate Policy.
+[Link](http://dx.doi.org/10.1080/14693062.2013.879794)
 
-Calvin, Katherine, Jae Edmonds, Bjorn Bakken, Marshall Wise, Son H. Kim, Patrick Luckow, Pralit Patel, Ingeborg Graabak.  (2014). The EU20-20-20 energy policy as a model for global climate mitigation.  Climate Policy http://dx.doi.org/10.1080/14693062.2013.879794.
+<a name="Mankiw2012">[Mankiw & Hakes 2012]</a> Mankiw, N.  and David Hakes (2012). Principles of microeconomics. South-Western Cengage Learning.
 
-Mankiw, N.  and David Hakes (2012). Principles of microeconomics. South-Western Cengage Learning.
-
+<a name="shi2017">[Shi et al. 2017]</a> Shi W, Ou Y, Smith S J, Ledna C M, Nolte C G, Loughlin D H 2017. "Projecting state-level air pollutant emissions using an integrated assessment model: GCAM-USA" *Applied Energy* 208 511–521. doi: 10.1016/j.apenergy.2017.09.122. [Link](https://www.sciencedirect.com/science/article/pii/S0306261917314125)
 

--- a/policies.md
+++ b/policies.md
@@ -6,22 +6,34 @@ gcam-version: v5.1
 
 One of GCAM's uses is to explore the implications of different future policies. There are a number of types of policies that can be easily modeled in GCAM. The most common of these are discussed below.
 
-## Emissions-Related Policies
-There are three main policy approaches that can be applied in GCAM to reduce emissions of CO2 or other greenhouse gases: carbon or GHG prices, emissions constraints, or climate constraints. In all cases, GCAM implements the policy approach by placing a price on emissions. This price then filters down through all the systems in GCAM and alters production and demand. For example, a price on carbon would put a cost on emitting fossil fuels. This cost would then influence the cost of producing electricity from fossil-fired power plants that emit CO2, which would then influence their relative cost compared to other electricity generating technologies and increase the price of electricity. The increased price of electricity would then make its way to consumers that use electricity, decreasing its competitiveness relative to other fuels and leading to a decrease in electricity demand. The three policy approaches are described below.
+Table Of Contents
+
+* [Emissions-Related Policies](#emissions-policies)
+    * [Linked Emission Markets](#linked-markets)
+    * [Markets For non-CO<sub>2</sub> Emission Species](#non-co2-markets)
+* [Land-Use Policies](#land-use-policies)
+* [Energy Production Policies](#energy-production-policies)
+* [Emissions-Related Policies](#emissions-policies)
+* [Calculating Emissions Policy Costs](#policy-costs)
+
+## <a name="emissions-policies"> Emissions-Related Policies </a>
+
+There are three main policy approaches that can be applied in GCAM to reduce emissions of CO<sub>2</sub> or other greenhouse gases: carbon or GHG prices, emissions constraints, or climate constraints. In all cases, GCAM implements the policy approach by placing a price on emissions. This price then filters down through all the systems in GCAM and alters production and demand. For example, a price on carbon would put a cost on emitting fossil fuels. This cost would then influence the cost of producing electricity from fossil-fired power plants that emit CO<sub>2</sub>, which would then influence their relative cost compared to other electricity generating technologies and increase the price of electricity. The increased price of electricity would then make its way to consumers that use electricity, decreasing its competitiveness relative to other fuels and leading to a decrease in electricity demand. The three policy approaches are described below.
 
 * Carbon or GHG prices: GCAM users can directly specify the price of carbon or GHGs. Given a carbon price, the resulting emissions will vary depending on other scenario drivers, such as population, GDP, resources, and technology.
 
-* Emissions constraints. GCAM users can specify the total amount of emissions (CO2 or GHG) as well. GCAM will then calculate the price of carbon needed to reach the constraint in each period of the constraint.
+* Emissions constraints. GCAM users can specify the total amount of emissions (CO<sub>2</sub> or GHG) as well. GCAM will then calculate the price of carbon needed to reach the constraint in each period of the constraint.
 
 * Climate constraints: GCAM users can specify a climate variable (e.g., concentration or radiative forcing) target for a particular year. Users determine whether that target can be exceeded prior to the target year. GCAM will adjust carbon prices in order to find the least cost path to reaching the target. (Note that this type of policy increases model run time significantly.)
 
-### Linked Emission Markets
+### <a name="linked-markets"> Linked Emission Markets </a>
+
 Emissions prices of different GHGs can be linked together for a multi-gas policy using the linked-ghg-policy object. For example, in the default [linked_ghg_policy.xml](https://github.com/JGCRI/gcam-core/blob/master/input/policy/linked_ghg_policy.xml) file in the GCAM release, all non-CO<sub>2</sub> GHGs are linked to the market for CO<sub>2</sub>. 
 
 The parameter price-adjust is used to convert prices (e.g., 100 year GWPs in the default set-up) and demand-adjust is used to convert demand units (e.g., to common units of carbon equivalents).
 These can be changed by year if desired.
 
-Setting price-adjust to zero means that there is no economic feedback for the price of this GHG. MAC curves, however, will still operate under the default set-up (whereby MAC curves are driven by CO<sub>2</sub> prices). This can be changed separately for energy/industrial/urban CH4, agricultural CH4 (CH4\_AGR), and CH4 from agricultural waste burning (CH4\_AWB), LUC CO<sub>2</sub> emissions (e.g. CO2_LUC).
+Setting price-adjust to zero means that there is no economic feedback for the price of this GHG. MAC curves, however, will still operate under the default set-up (whereby MAC curves are driven by CO<sub>2</sub> prices). This can be changed separately for energy/industrial/urban CH<sub>4</sub>, agricultural CH<sub>4</sub> (CH4\_AGR), and CH<sub>4</sub> from agricultural waste burning (CH4\_AWB), LUC CO<sub>2</sub> emissions (e.g. CO2_LUC).
 
 Note that you must first create a policy by reading in a <ghgpolicy> object (by reading an an XML with this object first, see the various policy files in the GCAM release) and then you can define how this links to any emissions (through <linked-ghg-policy> objects).
 
@@ -29,40 +41,11 @@ This flexibility allows CO<sub>2</sub>-only, CO<sub>2</sub>-equivalent, or non-C
 
 Note that the GCAM default set-up includes economic feedbacks for methane and nitrous oxide. This is an idealized assumption, but might not happen in real-world policies. For example, in many current systems agricultural emissions are offsets only – e.g., they get paid to reduce emissions, but are not charged for any remaining emissions. (So to simulate this type of policy, price-adjust would be set to zero).
 
-## Energy Production Policies
-There are times in which users would like to explore the implications of a constraint on production or a minimum production requirement. This capability allows GCAM users to model policies such as renewable portfolio standards and biofuels standards. Across sectors, these constraints must be applied as quantity constraints, but they can be applied as share constraints within individual sectors (e.g., fraction of electricity that comes from solar power). In implementing these policies, users This can either be a lower bound or upper bound. The model will solve for the tax (upper bound) or subsidy (lower bound) required to reach the given constraint.
+### <a name="non-co2-markets"> Markets For non-CO<sub>2</sub> Emission Species</a>
 
-## Land-Use Policies
-There are a number of ways that policies can be applied directly to influence the land sector in GCAM. These include the following.
+Markets in GCAM can be set for any emission species. (e.g., CH<sub>4</sub> -only market, NOx market, etc.)
 
-* Protected Lands: With this policy, GCAM users can set aside a fraction of natural land, removing it from economic competition. This land cannot be converted to crops, pasture, or any other land type. This is similar to real-world policies such as reducing emissions from deforestation and forest degradation (REDD). The default in GCAM is to protect 90% of all non-commercial ecosystems.
-
-* Valuing carbon in land: When applying a price on carbon through any of the emissions-related policy approaches, GCAM users can choose whether that price extends to land use change CO2 emissions. This policy is modeled as a subsidy to land-owners for the holding carbon stocks as opposed to a price on the emissions themselves.
-
-* Bioenergy constraints: GCAM users can impose constraints on bioenergy within GCAM. Under such a policy, GCAM will calculate the tax or subsidy required to ensure that the constraint is met. By default a bioenergy constraint in GCAM is imposed based on the amount of subsidy available for net negative emissions.
-
-## Calculating Emissions Policy Costs
-
-The cost of GHG emissions mitigation is a concept that is not uniquely defined. A wide range of measures are used in the literature. These include, the price of carbon (or as appropriate given the policy) needed to achieve a desired emission mitigation goal, reduction in Gross Domestic Product (GDP), consumption loss, deadweight loss, and equivalent variation. Beyond that the concept of net cost, which includes the benefits of emissions mitigation as well as the resource cost of emissions reduction and the social cost of carbon are also encountered. GCAM makes no attempt to calculate the benefits.
-
-In addition to identifying policy prices as one measure of cost, GCAM employs the “deadweight loss” approach to measuring welfare loss from emissions mitigation efforts. GCAM employs the deadweight loss approach for several reasons. First, the deadweight loss approach is numerically straight forward to calculate in GCAM. Second, the deadweight loss approach provides a computationally tractable method to measuring the change in welfare, though it is only an approximation. In principle the equivalent variation is the right approach to measure an individual’s loss in welfare. Equivalent variation measures the minimum amount of income that would be needed to leave consumers just as happy with the new price (e.g. carbon tax) as without. However, its calculation requires either knowledge of all of society’s individual preference functions or the existence of a well-ordered set of social preferences, a requirement that [Arrow (1950)](policies.html#Arrow1950) demonstrated to be impossible under ordinary circumstances. Third, the deadweight loss approach takes advantage of GCAM’s detailed technological characterization.
-
-A detailed description of the method used in GCAM is documented in [Bradley et al. (1991)](policies.html#Bradley1991). In general, the approach is as follows. GCAM calculates the cost of emissions mitigation at each GCAM time step. For example in the figure below, the cost of moving from a reference path without a carbon tax (blue) to the emissions path with a carbon tax (green) in period T can be calculated simply. Successive scenarios with fixed carbon taxes in period T are run. The associated emissions are recorded for each carbon tax. The cost is calculated as the area of the purple triangle, which is the integral of each emissions mitigation step weighted by the carbon tax that was required to deliver the reduction. The final ton of carbon emissions is the most expensive ton, because it is assumed that for a carbon tax, emissions mitigation occurs with the least expensive tons being reduced first. The final ton of carbon is simply the carbon tax rate itself. The tax revenue can be calculated as the tax rate times the remaining emissions, shown in red below.
-
-<img src="gcam-figs/policy cost.png" width="750" height="300" />
-
-As discussed in [Bradley et al. (1991)](policies.html#Bradley1991) and demonstrated in [Calvin et al. (2014)](policies.html#Calvin2014), the approach can be used to calculate costs for a wide range of heterogeneous non-price policies. While conceptually similar to the simple approach above, the other is tedious. Similarly, the deadweight loss approach can be used to calculate the cost of policies other than carbon taxes. It is completely general [Mankiw & Hakes (2012)](policies.html#Mankiw2012).
-
-
-The approach is employed at each GCAM time step. Costs occurring between time steps is inferred by interpolation. Costs over time can be summed. Costs can be summed with or without discounting. But, the GCAM user needs to be aware of the implications of whatever approach is employed.
-
-The deadweight loss approach is not without its limitations. While the numerical calculation is simple for a uniform carbon tax (or a cap-and-trade regime), more complex policies are more tedious to represent. Second, there is no link back to the macro-economy. Changes of the magnitude associated with stringent climate policies will have macro-economic consequences. Those consequence will, in turn affect the scale of economic activity. Third, there is no way to calculate the effects of alternative uses of tax revenue or carbon permit allocations.
-
-## <a name="non-co2-markets"> Markets For non-CO<sub>2</sub> Emission Species</a>
-
-Markets in GCAM can be set for any emission species. (e.g., CH4-only market, NOx market, etc.)
-
-Note that it generally does not make sense to set up an emissions market unless the model has a direct way to reduce emissions! (e.g. you’ve added relevant MAC curves.) For example, in [Shi et al. (2017)](policies.html#shi2017) US electricity sector SO<sub>2</sub> and NO<sub>x</sub> markets were used to represent current policies that cap emissions in certain states. MAC curves for existing power plants were added to allow emissions to change in response to market prices. 
+Note that it generally does not make sense to set up an emissions market unless the model has a direct way to reduce emissions. (e.g. you’ve added relevant MAC curves.) For example, in [Shi et al. (2017)](policies.html#shi2017) US electricity sector SO<sub>2</sub> and NO<sub>x</sub> markets were used to represent current policies that cap emissions in certain states. MAC curves for existing power plants were added to allow emissions to change in response to market prices. 
 
 xml inputs within the MAC curve that will be needed to set-up new markets are:
 
@@ -77,6 +60,39 @@ One additional MAC-curve option to note is:
 | | |
 ------------ | -------------
 zero-cost-phase-in-time | Number of years over which to phase-in "below-zero" MAC curve reductions (default = 25 years)
+
+## <a name="energy-production-policies"> Energy Production Policies </a>
+
+There are times in which users would like to explore the implications of a constraint on production or a minimum production requirement. This capability allows GCAM users to model policies such as renewable portfolio standards and biofuels standards. Across sectors, these constraints must be applied as quantity constraints, but they can be applied as share constraints within individual sectors (e.g., fraction of electricity that comes from solar power). In implementing these policies, users This can either be a lower bound or upper bound. The model will solve for the tax (upper bound) or subsidy (lower bound) required to reach the given constraint.
+
+## <a name="land-use-policies"> Land-Use Policies </a>
+
+There are a number of ways that policies can be applied directly to influence the land sector in GCAM. These include the following.
+
+* Protected Lands: With this policy, GCAM users can set aside a fraction of natural land, removing it from economic competition. This land cannot be converted to crops, pasture, or any other land type. This is similar to real-world policies such as reducing emissions from deforestation and forest degradation (REDD). The default in GCAM is to protect 90% of all non-commercial ecosystems.
+
+* Valuing carbon in land: When applying a price on carbon through any of the emissions-related policy approaches, GCAM users can choose whether that price extends to land use change CO<sub>2</sub> emissions. This policy is modeled as a subsidy to land-owners for the holding carbon stocks as opposed to a price on the emissions themselves.
+
+* Bioenergy constraints: GCAM users can impose constraints on bioenergy within GCAM. Under such a policy, GCAM will calculate the tax or subsidy required to ensure that the constraint is met. By default a bioenergy constraint in GCAM is imposed based on the amount of subsidy available for net negative emissions.
+
+## <a name="policy-costs"> Calculating Emissions Policy Costs </a>
+
+The cost of GHG emissions mitigation is a concept that is not uniquely defined. A wide range of measures are used in the literature. These include, the price of carbon (or as appropriate given the policy) needed to achieve a desired emission mitigation goal, reduction in Gross Domestic Product (GDP), consumption loss, deadweight loss, and equivalent variation. Beyond that the concept of net cost, which includes the benefits of emissions mitigation as well as the resource cost of emissions reduction and the social cost of carbon are also encountered. GCAM makes no attempt to calculate the benefits.
+
+In addition to identifying policy prices as one measure of cost, GCAM employs the “deadweight loss” approach to measuring welfare loss from emissions mitigation efforts. GCAM employs the deadweight loss approach for several reasons. First, the deadweight loss approach is numerically straight forward to calculate in GCAM. Second, the deadweight loss approach provides a computationally tractable method to measuring the change in welfare, though it is only an approximation. In principle the equivalent variation is the right approach to measure an individual’s loss in welfare. Equivalent variation measures the minimum amount of income that would be needed to leave consumers just as happy with the new price (e.g. carbon tax) as without. However, its calculation requires either knowledge of all of society’s individual preference functions or the existence of a well-ordered set of social preferences, a requirement that [Arrow (1950)](policies.html#Arrow1950) demonstrated to be impossible under ordinary circumstances. Third, the deadweight loss approach takes advantage of GCAM’s detailed technological characterization.
+
+A detailed description of the method used in GCAM is documented in [Bradley et al. (1991)](policies.html#Bradley1991). In general, the approach is as follows. GCAM calculates the cost of emissions mitigation at each GCAM time step. For example in the figure below, the cost of moving from a reference path without a carbon tax (blue) to the emissions path with a carbon tax (green) in period T can be calculated simply. Successive scenarios with fixed carbon taxes in period T are run. The associated emissions are recorded for each carbon tax. The cost is calculated as the area of the purple triangle, which is the integral of each emissions mitigation step weighted by the carbon tax that was required to deliver the reduction. The final ton of carbon emissions is the most expensive ton, because it is assumed that for a carbon tax, emissions mitigation occurs with the least expensive tons being reduced first. The final ton of carbon is simply the carbon tax rate itself. The tax revenue can be calculated as the tax rate times the remaining emissions, shown in red below.
+
+<img src="gcam-figs/policy cost.png" width="750" height="300" />
+
+As discussed in [Bradley et al. (1991)](policies.html#Bradley1991) and demonstrated in [Calvin et al. (2014)](policies.html#Calvin2014), the approach can be used to calculate costs for a wide range of heterogeneous non-price policies. While conceptually similar to the simple approach above, the other is tedious. Similarly, the deadweight loss approach can be used to calculate the cost of policies other than carbon taxes. It is completely general [Mankiw & Hakes (2012)](policies.html#Mankiw2012).
+
+The approach is employed at each GCAM time step. Costs occurring between time steps is inferred by interpolation. Costs over time can be summed. Costs can be summed with or without discounting. But, the GCAM user needs to be aware of the implications of whatever approach is employed.
+
+The deadweight loss approach is not without its limitations. While the numerical calculation is simple for a uniform carbon tax (or a cap-and-trade regime), more complex policies are more tedious to represent. Second, there is no link back to the macro-economy. Changes of the magnitude associated with stringent climate policies will have macro-economic consequences. Those consequence will, in turn affect the scale of economic activity. Third, there is no way to calculate the effects of alternative uses of tax revenue or carbon permit allocations.
+
+Note that calculation of policy costs is currently only supported for polices pegged to CO<sub>2</sub> prices. 
+
 
 ## References
 <a name="Arrow1950">[Arrow 1950]</a> Arrow, Kenneth J. (1950). "A Difficulty in the Concept of Social Welfare" (PDF). Journal of Political Economy. 58 (4): 328–346. doi:10.1086/256963.

--- a/toc.md
+++ b/toc.md
@@ -12,6 +12,7 @@ gcam-version: v5.1
 * [Agriculture, Land-Use, and Bioenergy](aglu.html)
 * [Water](water.html)
 * [Climate](hector.html) 
+* [Emissions](emissions.html)
 * [Economic Choice](choice.html)
 * [Solution and Computation](solver.html)
 * [Trade](trade.html)


### PR DESCRIPTION
As per @LC1000  request. Information on linked GHG markets and air-pollutant markets moved to policy page, with a link to that in the emissions page.