### PR TITLE
Omnibus bugfix 5.1.3 documentation updates

### DIFF
--- a/user-guide.md
+++ b/user-guide.md
@@ -165,6 +165,7 @@ scenarioName | Name of the scenario. This name will be embedded in output xml da
 debug-region | String that specifies which region is used for debugging output (see xmlDebugFileName), which provides a dump, by model period, of GCAM internal state variables which can be useful for debugging and understanding results.
 MAGICC-input-dir | Input directory for necessary MAGICC input files. This normally should not be changed.
 MAGICC-output-dir | Directory for MAGICC model output files.
+AbatedGasForCostCurves | Default: "CO2".  The name of the market/gas to change the price of and sum emissions for when calculating [Policy Costs](policies.html#policy-costs).  Note when [targeting multiple gasses](policies.html#linked-markets) you may specificy this value as `GHG;CO2;CH4;N2O;C2F6;CF4`, for example, to list all of the gasses to sum and they will be weighted according to the linked ghg policy
 
 #### 3.1.4 `<Bools>` Input Options
 


### PR DESCRIPTION
Add note about AbatedGasForCostCurves and updates to allow summing linked GHG policies