### PR TITLE
Fix CSS link resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 _site
 
 .jekyll-metadata
+.jekyll-cache
 
 # Emacs stuff
 *~

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,2 @@
 timezone: America/New_York
 encoding: utf-8
-url: //jgcri.github.io/gcam-doc

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
 timezone: America/New_York
 encoding: utf-8
-url: http://jgcri.github.io/gcam-doc
+url: //jgcri.github.io/gcam-doc

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -5,11 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <title>GCAM {{page.gcam-version}} Documentation: {{page.title}}</title>
 
-    <link rel="stylesheet" href="{{site.url}}/stylesheets/styles.css">
-    <link rel="stylesheet" href="{{site.url}}/stylesheets/github-dark.css">
-    <link rel="shortcut icon" href="{{site.url}}/images/logo.gif">
-    <script src="{{site.url}}/javascripts/scale.fix.js"></script>
-    <script src="{{site.url}}/javascripts/load_queries.js"></script>
+    <link rel="stylesheet" href="{{site.baseurl}}/stylesheets/styles.css">
+    <link rel="stylesheet" href="{{site.baseurl}}/stylesheets/github-dark.css">
+    <link rel="shortcut icon" href="{{site.baseurl}}/images/logo.gif">
+    <script src="{{site.baseurl}}/javascripts/scale.fix.js"></script>
+    <script src="{{site.baseurl}}/javascripts/load_queries.js"></script>
     <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 
@@ -30,7 +30,7 @@
         </ul>
 	<hr/>
 	<p class="nav">
-	  <a href="{{site.url}}/index.html">[Home]</a>
+	  <a href="{{site.baseurl}}/index.html">[Home]</a>
 	  {% if page.devguide %}
       <a href="../toc.html">[Table of Contents{% if page.gcam-version %}
 	    ({{page.gcam-version}}){% endif %}]</a>


### PR DESCRIPTION
Previous attempts to deal with resolving the path to the CSS resources (and Javascript etc) when rendering the site officially or locally for development no longer work due to http/https issues.  However, I think the most appropriate way to deal wiht it is to note set anything at al in the config and instead let Githuh set `site.baseurl` appropriately,.