### PR TITLE
Add a search bar to the documentation site

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -10,8 +10,10 @@
     <link rel="shortcut icon" href="{{site.baseurl}}/images/logo.gif">
     <script src="{{site.baseurl}}/javascripts/scale.fix.js"></script>
     <script src="{{site.baseurl}}/javascripts/load_queries.js"></script>
+    <script src="{{site.baseurl}}/javascripts/search.js" defer></script>
     <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+    <meta name="gcam-baseurl" content="{{site.baseurl}}">
 
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -29,6 +31,12 @@
           <li><a href="https://github.com/JGCRI/gcam-core">View On <strong>GitHub</strong></a></li>
         </ul>
 	<hr/>
+	<div class="gcam-search-box">
+	  <input type="search" id="gcam-search-input" placeholder="Search documentation…" autocomplete="off" aria-label="Search documentation">
+	  <div id="gcam-search-overlay" hidden>
+	    <ul id="gcam-search-results"></ul>
+	  </div>
+	</div>
 	<p class="nav">
 	  <a href="{{site.baseurl}}/index.html">[Home]</a>
 	  {% if page.devguide %}

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -51,6 +51,7 @@
 	  </p>
 	  <div class="gcam-search-box">
 	    <input type="search" id="gcam-search-input" placeholder="Search…" autocomplete="off" aria-label="Search documentation">
+	    <button type="button" id="gcam-search-button" aria-label="Search">Search</button>
 	    <div id="gcam-search-overlay" hidden>
 	      <ul id="gcam-search-results"></ul>
 	    </div>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -13,7 +13,7 @@
     <script src="{{site.baseurl}}/javascripts/search.js" defer></script>
     <script type="text/javascript" async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
-    <meta name="gcam-baseurl" content="{{site.baseurl}}">
+    <meta name="gcam-search-url" content="{{ '/search.json' | relative_url }}">
 
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
@@ -31,29 +31,31 @@
           <li><a href="https://github.com/JGCRI/gcam-core">View On <strong>GitHub</strong></a></li>
         </ul>
 	<hr/>
-	<div class="gcam-search-box">
-	  <input type="search" id="gcam-search-input" placeholder="Search documentation…" autocomplete="off" aria-label="Search documentation">
-	  <div id="gcam-search-overlay" hidden>
-	    <ul id="gcam-search-results"></ul>
+	<div class="gcam-nav-row">
+	  <p class="nav">
+	    <a href="{{site.baseurl}}/index.html">[Home]</a>
+	    {% if page.devguide %}
+	    <a href="../toc.html">[Table of Contents{% if page.gcam-version %}
+	      ({{page.gcam-version}}){% endif %}]</a>
+	    <a href="../dev-guide.html">[Developer Guide Table of Contents]</a>
+	    {% else %}
+	    <a href="toc.html">[Table of Contents{% if page.gcam-version %}
+	      ({{page.gcam-version}}){% endif %}]</a>
+	    {% endif %}
+	    {% if page.prev %}
+	    <a href="{{page.prev}}">[Previous page]</a>
+	    {% endif %}
+	    {% if page.next %}
+	    <a href="{{page.next}}">[Next page]</a>
+	    {% endif %}
+	  </p>
+	  <div class="gcam-search-box">
+	    <input type="search" id="gcam-search-input" placeholder="Search…" autocomplete="off" aria-label="Search documentation">
+	    <div id="gcam-search-overlay" hidden>
+	      <ul id="gcam-search-results"></ul>
+	    </div>
 	  </div>
 	</div>
-	<p class="nav">
-	  <a href="{{site.baseurl}}/index.html">[Home]</a>
-	  {% if page.devguide %}
-      <a href="../toc.html">[Table of Contents{% if page.gcam-version %}
-	    ({{page.gcam-version}}){% endif %}]</a>
-      <a href="../dev-guide.html">[Developer Guide Table of Contents]</a>
-	  {% else %}
-      <a href="toc.html">[Table of Contents{% if page.gcam-version %}
-	    ({{page.gcam-version}}){% endif %}]</a>
-	  {% endif %}
-	  {% if page.prev %}
-	  <a href="{{page.prev}}">[Previous page]</a>
-	  {% endif %}
-	  {% if page.next %}
-	  <a href="{{page.next}}">[Next page]</a>
-	  {% endif %}
-	</p>
       </header>
       <section>
         <h1>

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -1,159 +1,73 @@
 /**
  * Client-side full-text search for GCAM documentation.
  *
- * On first use, fetches search.json (built by Jekyll at build time) and indexes
- * all pages.  Searches are simple case-insensitive substring matches — fast
- * enough for the ~40-page corpus and zero external dependencies.
+ * Fetches a Jekyll-generated JSON index of all pages on first use,
+ * then performs case-insensitive substring matching with snippet previews.
+ * Zero external dependencies.
  */
 (function () {
   'use strict';
 
-  var index = null;       // Array of { title, url, content, lower }
-  var overlay = null;     // DOM: results overlay
-  var resultsList = null; // DOM: <ul> inside overlay
-  var input = null;       // DOM: search <input>
-  var button = null;      // DOM: search <button>
-  var timer = null;
+  var INDEX = null;          // Loaded page index
+  var INDEX_LOADING = false; // Single-flight flag
+  var INDEX_CALLBACKS = [];  // Queued callbacks while loading
 
-  // ---- Bootstrap ----
+  function $(id) { return document.getElementById(id); }
 
-  function init() {
-    input = document.getElementById('gcam-search-input');
-    button = document.getElementById('gcam-search-button');
-    overlay = document.getElementById('gcam-search-overlay');
-    resultsList = document.getElementById('gcam-search-results');
-    if (!input || !overlay || !resultsList) return;
-
-    // Live search as you type
-    input.addEventListener('input', function () {
-      clearTimeout(timer);
-      timer = setTimeout(function () { runSearch(input.value.trim()); }, 200);
-    });
-
-    // Enter key triggers search immediately
-    input.addEventListener('keydown', function (e) {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        clearTimeout(timer);
-        runSearch(input.value.trim());
-      } else if (e.key === 'Escape') {
-        input.value = '';
-        hideOverlay();
-      }
-    });
-
-    // Click on the Search button
-    if (button) {
-      button.addEventListener('click', function (e) {
-        e.preventDefault();
-        runSearch(input.value.trim());
-      });
-    }
-
-    // Close overlay when clicking outside the search box
-    document.addEventListener('click', function (e) {
-      if (!overlay.contains(e.target) && e.target !== input && e.target !== button) {
-        hideOverlay();
-      }
-    });
+  function escapeHtml(s) {
+    return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   }
 
-  // ---- Index loading ----
+  function getSearchUrl() {
+    var meta = document.querySelector('meta[name="gcam-search-url"]');
+    return meta ? meta.getAttribute('content') : '/search.json';
+  }
 
   function loadIndex(cb) {
-    if (index) return cb();
-    var meta = document.querySelector('meta[name="gcam-search-url"]');
-    var url = meta ? meta.getAttribute('content') : '/search.json';
+    if (INDEX) { cb(null, INDEX); return; }
+    INDEX_CALLBACKS.push(cb);
+    if (INDEX_LOADING) return;
+    INDEX_LOADING = true;
 
+    var url = getSearchUrl();
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', url);
-    xhr.onload = function () {
-      if (xhr.status === 200) {
-        try {
+    xhr.open('GET', url, true);
+    xhr.onreadystatechange = function () {
+      if (xhr.readyState !== 4) return;
+      var err = null;
+      try {
+        if (xhr.status >= 200 && xhr.status < 300) {
           var data = JSON.parse(xhr.responseText);
-          index = data.map(function (d) {
+          if (!Array.isArray(data)) throw new Error('search.json is not an array');
+          INDEX = data.map(function (d) {
+            var title = String(d.title || '');
+            var content = String(d.content || '');
             return {
-              title: d.title,
-              url: d.url,
-              content: d.content,
-              lower: (d.title + ' ' + d.content).toLowerCase()
+              title: title,
+              url: String(d.url || '#'),
+              content: content,
+              lower: (title + ' ' + content).toLowerCase()
             };
           });
-        } catch (e) {
-          index = [];
+        } else {
+          err = new Error('HTTP ' + xhr.status + ' loading ' + url);
         }
-      } else {
-        index = [];
+      } catch (e) {
+        err = e;
       }
-      cb();
+      var cbs = INDEX_CALLBACKS;
+      INDEX_CALLBACKS = [];
+      INDEX_LOADING = false;
+      for (var i = 0; i < cbs.length; i++) cbs[i](err, INDEX);
     };
-    xhr.onerror = function () { index = []; cb(); };
     xhr.send();
   }
 
-  // ---- Search ----
-
-  function runSearch(query) {
-    if (!query) { hideOverlay(); return; }
-
-    loadIndex(function () {
-      var qLower = query.toLowerCase();
-      var hits = [];
-
-      for (var i = 0; i < index.length; i++) {
-        var page = index[i];
-        var pos = page.lower.indexOf(qLower);
-        if (pos === -1) continue;
-
-        // Count matches
-        var count = 0;
-        var idx = 0;
-        while ((idx = page.lower.indexOf(qLower, idx)) !== -1) {
-          count++;
-          idx += qLower.length;
-          if (count > 100) break;
-        }
-
-        // Find position in content (skip title prefix)
-        var contentPos = page.content.toLowerCase().indexOf(qLower);
-
-        hits.push({ page: page, count: count, contentPos: contentPos });
-      }
-
-      if (hits.length === 0) {
-        showOverlay();
-        resultsList.innerHTML = '<li class="gcam-search-empty">No results for "' + escapeHtml(query) + '"</li>';
-        return;
-      }
-
-      // Sort: more matches first
-      hits.sort(function (a, b) { return b.count - a.count; });
-
-      var html = '';
-      for (var j = 0; j < hits.length; j++) {
-        var h = hits[j];
-        var snip = h.contentPos >= 0
-          ? makeSnippet(h.page.content, h.contentPos, query)
-          : '';
-        html += '<li><a href="' + escapeHtml(h.page.url) + '">'
-          + '<div class="gcam-search-title">' + escapeHtml(h.page.title)
-          + ' <span class="gcam-search-count">' + h.count + '</span></div>'
-          + (snip ? '<div class="gcam-search-snippet">' + snip + '</div>' : '')
-          + '</a></li>';
-      }
-      showOverlay();
-      resultsList.innerHTML = html;
-    });
-  }
-
-  // ---- Helpers ----
-
   function makeSnippet(text, pos, query) {
     var start = Math.max(0, pos - 40);
-    var end = Math.min(text.length, pos + query.length + 80);
+    var end = Math.min(text.length, pos + query.length + 100);
     var s = text.slice(start, end).replace(/\s+/g, ' ').trim();
-
-    // Highlight all occurrences of query in snippet
     var lower = s.toLowerCase();
     var qLower = query.toLowerCase();
     var out = '';
@@ -169,15 +83,126 @@
     return out;
   }
 
-  function escapeHtml(s) {
-    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-      .replace(/"/g, '&quot;');
+  function renderResults(overlay, resultsList, query, hits) {
+    overlay.hidden = false;
+    overlay.removeAttribute('hidden');
+    overlay.style.display = 'block';
+
+    if (!hits || hits.length === 0) {
+      resultsList.innerHTML =
+        '<li class="gcam-search-empty">No results for "' + escapeHtml(query) + '"</li>';
+      return;
+    }
+    var html = '';
+    for (var i = 0; i < hits.length; i++) {
+      var h = hits[i];
+      var snip = h.contentPos >= 0
+        ? makeSnippet(h.page.content, h.contentPos, query) : '';
+      html += '<li><a href="' + escapeHtml(h.page.url) + '">'
+        + '<div class="gcam-search-title">' + escapeHtml(h.page.title)
+        + ' <span class="gcam-search-count">' + h.count + '</span></div>'
+        + (snip ? '<div class="gcam-search-snippet">' + snip + '</div>' : '')
+        + '</a></li>';
+    }
+    resultsList.innerHTML = html;
   }
 
-  function showOverlay() { overlay.hidden = false; }
-  function hideOverlay() { overlay.hidden = true; resultsList.innerHTML = ''; }
+  function runSearch(query, overlay, resultsList) {
+    query = (query || '').trim();
+    if (!query) {
+      overlay.hidden = true;
+      overlay.style.display = 'none';
+      resultsList.innerHTML = '';
+      return;
+    }
 
-  // ---- Go ----
+    // Show loading state immediately
+    overlay.hidden = false;
+    overlay.removeAttribute('hidden');
+    overlay.style.display = 'block';
+    resultsList.innerHTML =
+      '<li class="gcam-search-empty">Loading&hellip;</li>';
+
+    loadIndex(function (err, index) {
+      if (err) {
+        resultsList.innerHTML =
+          '<li class="gcam-search-empty">Search index failed to load: '
+          + escapeHtml(err.message) + '</li>';
+        return;
+      }
+      var qLower = query.toLowerCase();
+      var hits = [];
+      for (var i = 0; i < index.length; i++) {
+        var page = index[i];
+        if (page.lower.indexOf(qLower) === -1) continue;
+        var count = 0, idx = 0;
+        while ((idx = page.lower.indexOf(qLower, idx)) !== -1) {
+          count++; idx += qLower.length;
+          if (count > 200) break;
+        }
+        hits.push({
+          page: page,
+          count: count,
+          contentPos: page.content.toLowerCase().indexOf(qLower)
+        });
+      }
+      hits.sort(function (a, b) { return b.count - a.count; });
+      renderResults(overlay, resultsList, query, hits);
+    });
+  }
+
+  function init() {
+    var input = $('gcam-search-input');
+    var button = $('gcam-search-button');
+    var overlay = $('gcam-search-overlay');
+    var resultsList = $('gcam-search-results');
+
+    if (!input || !overlay || !resultsList) {
+      // Search UI not present on this page — nothing to do.
+      return;
+    }
+
+    var debounceTimer;
+    function go() { runSearch(input.value, overlay, resultsList); }
+
+    input.addEventListener('input', function () {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(go, 200);
+    });
+
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        clearTimeout(debounceTimer);
+        go();
+      } else if (e.key === 'Escape') {
+        input.value = '';
+        overlay.hidden = true;
+        overlay.style.display = 'none';
+        resultsList.innerHTML = '';
+      }
+    });
+
+    if (button) {
+      button.addEventListener('click', function (e) {
+        e.preventDefault();
+        clearTimeout(debounceTimer);
+        go();
+      });
+    }
+
+    // Close overlay when clicking outside the search box.
+    // Use the search-box wrapper so clicks anywhere inside (input, button,
+    // results) keep it open.
+    var box = input.closest('.gcam-search-box');
+    document.addEventListener('click', function (e) {
+      if (box && !box.contains(e.target)) {
+        overlay.hidden = true;
+        overlay.style.display = 'none';
+      }
+    });
+  }
+
   if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init);
   } else {

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -94,11 +94,16 @@
       return;
     }
     var html = '';
+    var q = encodeURIComponent(query);
     for (var i = 0; i < hits.length; i++) {
       var h = hits[i];
       var snip = h.contentPos >= 0
         ? makeSnippet(h.page.content, h.contentPos, query) : '';
-      html += '<li><a href="' + escapeHtml(h.page.url) + '">'
+      // Append ?q=... so the landing page can scroll to and highlight the match
+      var hrefBase = h.page.url;
+      var sep = hrefBase.indexOf('?') === -1 ? '?' : '&';
+      var href = hrefBase + sep + 'q=' + q;
+      html += '<li><a href="' + escapeHtml(href) + '">'
         + '<div class="gcam-search-title">' + escapeHtml(h.page.title)
         + ' <span class="gcam-search-count">' + h.count + '</span></div>'
         + (snip ? '<div class="gcam-search-snippet">' + snip + '</div>' : '')
@@ -151,12 +156,90 @@
     });
   }
 
+  // ---- Highlight the search term within the current page (?q=...) ----
+
+  function getQueryParam(name) {
+    var pairs = (location.search || '').replace(/^\?/, '').split('&');
+    for (var i = 0; i < pairs.length; i++) {
+      var kv = pairs[i].split('=');
+      if (decodeURIComponent(kv[0] || '') === name) {
+        return decodeURIComponent((kv[1] || '').replace(/\+/g, ' '));
+      }
+    }
+    return '';
+  }
+
+  function highlightOnPage(query) {
+    if (!query) return;
+    var root = document.querySelector('.wrapper section') || document.body;
+    if (!root) return;
+
+    var qLower = query.toLowerCase();
+    var walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode: function (n) {
+        if (!n.parentNode) return NodeFilter.FILTER_REJECT;
+        var tag = n.parentNode.nodeName;
+        if (tag === 'SCRIPT' || tag === 'STYLE' || tag === 'MARK') {
+          return NodeFilter.FILTER_REJECT;
+        }
+        // Skip the search box itself
+        if (n.parentNode.closest && n.parentNode.closest('.gcam-search-box')) {
+          return NodeFilter.FILTER_REJECT;
+        }
+        return n.nodeValue.toLowerCase().indexOf(qLower) === -1
+          ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT;
+      }
+    });
+
+    var matched = [];
+    var node;
+    while ((node = walker.nextNode())) {
+      matched.push(node);
+      if (matched.length > 500) break; // safety cap
+    }
+
+    var firstMark = null;
+    for (var i = 0; i < matched.length; i++) {
+      var n = matched[i];
+      var text = n.nodeValue;
+      var lower = text.toLowerCase();
+      var frag = document.createDocumentFragment();
+      var idx = 0, j;
+      while ((j = lower.indexOf(qLower, idx)) !== -1) {
+        if (j > idx) frag.appendChild(document.createTextNode(text.slice(idx, j)));
+        var mark = document.createElement('mark');
+        mark.className = 'gcam-page-highlight';
+        mark.textContent = text.slice(j, j + query.length);
+        if (!firstMark) {
+          mark.classList.add('gcam-page-highlight-first');
+          firstMark = mark;
+        }
+        frag.appendChild(mark);
+        idx = j + query.length;
+      }
+      if (idx < text.length) frag.appendChild(document.createTextNode(text.slice(idx)));
+      n.parentNode.replaceChild(frag, n);
+    }
+
+    if (firstMark) {
+      setTimeout(function () {
+        firstMark.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }, 100);
+    }
+  }
+
   function init() {
+    var pageQuery = getQueryParam('q');
+    if (pageQuery) highlightOnPage(pageQuery);
+
     var input = $('gcam-search-input');
     var button = $('gcam-search-button');
     var overlay = $('gcam-search-overlay');
     var resultsList = $('gcam-search-results');
     if (!input || !overlay || !resultsList) return;
+
+    // Pre-fill the search box with the query that brought us here
+    if (pageQuery && !input.value) input.value = pageQuery;
 
     var debounceTimer;
     function go() { runSearch(input.value, overlay, resultsList); }

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -12,31 +12,47 @@
   var overlay = null;     // DOM: results overlay
   var resultsList = null; // DOM: <ul> inside overlay
   var input = null;       // DOM: search <input>
+  var button = null;      // DOM: search <button>
   var timer = null;
 
   // ---- Bootstrap ----
 
   function init() {
     input = document.getElementById('gcam-search-input');
+    button = document.getElementById('gcam-search-button');
     overlay = document.getElementById('gcam-search-overlay');
     resultsList = document.getElementById('gcam-search-results');
     if (!input || !overlay || !resultsList) return;
 
+    // Live search as you type
     input.addEventListener('input', function () {
       clearTimeout(timer);
       timer = setTimeout(function () { runSearch(input.value.trim()); }, 200);
     });
 
+    // Enter key triggers search immediately
     input.addEventListener('keydown', function (e) {
-      if (e.key === 'Escape') {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        clearTimeout(timer);
+        runSearch(input.value.trim());
+      } else if (e.key === 'Escape') {
         input.value = '';
         hideOverlay();
       }
     });
 
-    // Close overlay when clicking outside
+    // Click on the Search button
+    if (button) {
+      button.addEventListener('click', function (e) {
+        e.preventDefault();
+        runSearch(input.value.trim());
+      });
+    }
+
+    // Close overlay when clicking outside the search box
     document.addEventListener('click', function (e) {
-      if (!overlay.contains(e.target) && e.target !== input) {
+      if (!overlay.contains(e.target) && e.target !== input && e.target !== button) {
         hideOverlay();
       }
     });

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -8,6 +8,8 @@
 (function () {
   'use strict';
 
+  console.log('[gcam-search] script loaded');
+
   var INDEX = null;          // Loaded page index
   var INDEX_LOADING = false; // Single-flight flag
   var INDEX_CALLBACKS = [];  // Queued callbacks while loading
@@ -152,18 +154,23 @@
   }
 
   function init() {
+    console.log('[gcam-search] init() running');
     var input = $('gcam-search-input');
     var button = $('gcam-search-button');
     var overlay = $('gcam-search-overlay');
     var resultsList = $('gcam-search-results');
+    console.log('[gcam-search] elements:', { input: !!input, button: !!button, overlay: !!overlay, resultsList: !!resultsList });
 
     if (!input || !overlay || !resultsList) {
-      // Search UI not present on this page — nothing to do.
+      console.warn('[gcam-search] missing elements, aborting');
       return;
     }
 
     var debounceTimer;
-    function go() { runSearch(input.value, overlay, resultsList); }
+    function go() {
+      console.log('[gcam-search] go() called with value:', input.value);
+      runSearch(input.value, overlay, resultsList);
+    }
 
     input.addEventListener('input', function () {
       clearTimeout(debounceTimer);
@@ -185,10 +192,13 @@
 
     if (button) {
       button.addEventListener('click', function (e) {
+        console.log('[gcam-search] button clicked');
         e.preventDefault();
         clearTimeout(debounceTimer);
         go();
       });
+    } else {
+      console.warn('[gcam-search] button not found');
     }
 
     // Close overlay when clicking outside the search box.

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -103,8 +103,14 @@
       var hrefBase = h.page.url;
       var sep = hrefBase.indexOf('?') === -1 ? '?' : '&';
       var href = hrefBase + sep + 'q=' + q;
+      // Extract version from URL path (e.g. /gcam-doc/v3.2/foo.html -> v3.2).
+      // Pages under no version subdirectory are the current docs ("current").
+      var verLabel = '';
+      var verMatch = h.page.url.match(/\/(v\d+(?:\.\d+)?)\//);
+      verLabel = verMatch ? verMatch[1] : 'current';
       html += '<li><a href="' + escapeHtml(href) + '">'
         + '<div class="gcam-search-title">' + escapeHtml(h.page.title)
+        + ' <span class="gcam-search-version">' + escapeHtml(verLabel) + '</span>'
         + ' <span class="gcam-search-count">' + h.count + '</span></div>'
         + (snip ? '<div class="gcam-search-snippet">' + snip + '</div>' : '')
         + '</a></li>';

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -158,7 +158,15 @@
           contentPos: page.content.toLowerCase().indexOf(qLower)
         });
       }
-      hits.sort(function (a, b) { return b.count - a.count; });
+      // Sort: current-version pages first (no /vX.Y/ in URL), then archived;
+      // within each group, more matches first.
+      var archivedRe = /\/v\d+(?:\.\d+)?\//;
+      hits.sort(function (a, b) {
+        var aArch = archivedRe.test(a.page.url) ? 1 : 0;
+        var bArch = archivedRe.test(b.page.url) ? 1 : 0;
+        if (aArch !== bArch) return aArch - bArch;
+        return b.count - a.count;
+      });
       renderResults(overlay, resultsList, query, hits);
     });
   }

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -1,0 +1,171 @@
+/**
+ * Client-side full-text search for GCAM documentation.
+ *
+ * On first use, fetches search.json (built by Jekyll at build time) and indexes
+ * all pages.  Searches are simple case-insensitive substring matches — fast
+ * enough for the ~40-page corpus and zero external dependencies.
+ */
+(function () {
+  'use strict';
+
+  var index = null;       // Array of { title, url, content, lower }
+  var overlay = null;     // DOM: results overlay
+  var resultsList = null; // DOM: <ul> inside overlay
+  var input = null;       // DOM: search <input>
+  var timer = null;
+
+  // ---- Bootstrap ----
+
+  function init() {
+    input = document.getElementById('gcam-search-input');
+    overlay = document.getElementById('gcam-search-overlay');
+    resultsList = document.getElementById('gcam-search-results');
+    if (!input || !overlay || !resultsList) return;
+
+    input.addEventListener('input', function () {
+      clearTimeout(timer);
+      timer = setTimeout(function () { runSearch(input.value.trim()); }, 200);
+    });
+
+    input.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        input.value = '';
+        hideOverlay();
+      }
+    });
+
+    // Close overlay when clicking outside
+    document.addEventListener('click', function (e) {
+      if (!overlay.contains(e.target) && e.target !== input) {
+        hideOverlay();
+      }
+    });
+  }
+
+  // ---- Index loading ----
+
+  function loadIndex(cb) {
+    if (index) return cb();
+    var base = document.querySelector('meta[name="gcam-baseurl"]');
+    var baseUrl = base ? base.getAttribute('content') : '';
+    var url = baseUrl + '/search.json';
+
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url);
+    xhr.onload = function () {
+      if (xhr.status === 200) {
+        try {
+          var data = JSON.parse(xhr.responseText);
+          index = data.map(function (d) {
+            return {
+              title: d.title,
+              url: d.url,
+              content: d.content,
+              lower: (d.title + ' ' + d.content).toLowerCase()
+            };
+          });
+        } catch (e) {
+          index = [];
+        }
+      } else {
+        index = [];
+      }
+      cb();
+    };
+    xhr.onerror = function () { index = []; cb(); };
+    xhr.send();
+  }
+
+  // ---- Search ----
+
+  function runSearch(query) {
+    if (!query) { hideOverlay(); return; }
+
+    loadIndex(function () {
+      var qLower = query.toLowerCase();
+      var hits = [];
+
+      for (var i = 0; i < index.length; i++) {
+        var page = index[i];
+        var pos = page.lower.indexOf(qLower);
+        if (pos === -1) continue;
+
+        // Count matches
+        var count = 0;
+        var idx = 0;
+        while ((idx = page.lower.indexOf(qLower, idx)) !== -1) {
+          count++;
+          idx += qLower.length;
+          if (count > 100) break;
+        }
+
+        // Find position in content (skip title prefix)
+        var contentPos = page.content.toLowerCase().indexOf(qLower);
+
+        hits.push({ page: page, count: count, contentPos: contentPos });
+      }
+
+      if (hits.length === 0) {
+        showOverlay();
+        resultsList.innerHTML = '<li class="gcam-search-empty">No results for "' + escapeHtml(query) + '"</li>';
+        return;
+      }
+
+      // Sort: more matches first
+      hits.sort(function (a, b) { return b.count - a.count; });
+
+      var html = '';
+      for (var j = 0; j < hits.length; j++) {
+        var h = hits[j];
+        var snip = h.contentPos >= 0
+          ? makeSnippet(h.page.content, h.contentPos, query)
+          : '';
+        html += '<li><a href="' + escapeHtml(h.page.url) + '">'
+          + '<div class="gcam-search-title">' + escapeHtml(h.page.title)
+          + ' <span class="gcam-search-count">' + h.count + '</span></div>'
+          + (snip ? '<div class="gcam-search-snippet">' + snip + '</div>' : '')
+          + '</a></li>';
+      }
+      showOverlay();
+      resultsList.innerHTML = html;
+    });
+  }
+
+  // ---- Helpers ----
+
+  function makeSnippet(text, pos, query) {
+    var start = Math.max(0, pos - 40);
+    var end = Math.min(text.length, pos + query.length + 80);
+    var s = text.slice(start, end).replace(/\s+/g, ' ').trim();
+
+    // Highlight all occurrences of query in snippet
+    var lower = s.toLowerCase();
+    var qLower = query.toLowerCase();
+    var out = '';
+    var i = 0, j;
+    while ((j = lower.indexOf(qLower, i)) !== -1) {
+      out += escapeHtml(s.slice(i, j));
+      out += '<mark>' + escapeHtml(s.slice(j, j + qLower.length)) + '</mark>';
+      i = j + qLower.length;
+    }
+    out += escapeHtml(s.slice(i));
+    if (start > 0) out = '&hellip; ' + out;
+    if (end < text.length) out += ' &hellip;';
+    return out;
+  }
+
+  function escapeHtml(s) {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function showOverlay() { overlay.hidden = false; }
+  function hideOverlay() { overlay.hidden = true; resultsList.innerHTML = ''; }
+
+  // ---- Go ----
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -8,8 +8,6 @@
 (function () {
   'use strict';
 
-  console.log('[gcam-search] script loaded');
-
   var INDEX = null;          // Loaded page index
   var INDEX_LOADING = false; // Single-flight flag
   var INDEX_CALLBACKS = [];  // Queued callbacks while loading
@@ -86,14 +84,9 @@
   }
 
   function renderResults(overlay, resultsList, query, hits) {
-    console.log('[gcam-search] renderResults:', hits ? hits.length : 0, 'hits');
     overlay.hidden = false;
     overlay.removeAttribute('hidden');
     overlay.style.display = 'block';
-    overlay.style.visibility = 'visible';
-    overlay.style.opacity = '1';
-    var rect = overlay.getBoundingClientRect();
-    console.log('[gcam-search] overlay rect:', rect.top, rect.left, rect.width, rect.height);
 
     if (!hits || hits.length === 0) {
       resultsList.innerHTML =
@@ -159,23 +152,14 @@
   }
 
   function init() {
-    console.log('[gcam-search] init() running');
     var input = $('gcam-search-input');
     var button = $('gcam-search-button');
     var overlay = $('gcam-search-overlay');
     var resultsList = $('gcam-search-results');
-    console.log('[gcam-search] elements:', { input: !!input, button: !!button, overlay: !!overlay, resultsList: !!resultsList });
-
-    if (!input || !overlay || !resultsList) {
-      console.warn('[gcam-search] missing elements, aborting');
-      return;
-    }
+    if (!input || !overlay || !resultsList) return;
 
     var debounceTimer;
-    function go() {
-      console.log('[gcam-search] go() called with value:', input.value);
-      runSearch(input.value, overlay, resultsList);
-    }
+    function go() { runSearch(input.value, overlay, resultsList); }
 
     input.addEventListener('input', function () {
       clearTimeout(debounceTimer);
@@ -197,13 +181,10 @@
 
     if (button) {
       button.addEventListener('click', function (e) {
-        console.log('[gcam-search] button clicked');
         e.preventDefault();
         clearTimeout(debounceTimer);
         go();
       });
-    } else {
-      console.warn('[gcam-search] button not found');
     }
 
     // Close overlay when clicking outside the search box.

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -46,9 +46,8 @@
 
   function loadIndex(cb) {
     if (index) return cb();
-    var base = document.querySelector('meta[name="gcam-baseurl"]');
-    var baseUrl = base ? base.getAttribute('content') : '';
-    var url = baseUrl + '/search.json';
+    var meta = document.querySelector('meta[name="gcam-search-url"]');
+    var url = meta ? meta.getAttribute('content') : '/search.json';
 
     var xhr = new XMLHttpRequest();
     xhr.open('GET', url);

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -86,9 +86,14 @@
   }
 
   function renderResults(overlay, resultsList, query, hits) {
+    console.log('[gcam-search] renderResults:', hits ? hits.length : 0, 'hits');
     overlay.hidden = false;
     overlay.removeAttribute('hidden');
     overlay.style.display = 'block';
+    overlay.style.visibility = 'visible';
+    overlay.style.opacity = '1';
+    var rect = overlay.getBoundingClientRect();
+    console.log('[gcam-search] overlay rect:', rect.top, rect.left, rect.width, rect.height);
 
     if (!hits || hits.length === 0) {
       resultsList.innerHTML =

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -104,13 +104,14 @@
       var sep = hrefBase.indexOf('?') === -1 ? '?' : '&';
       var href = hrefBase + sep + 'q=' + q;
       // Extract version from URL path (e.g. /gcam-doc/v3.2/foo.html -> v3.2).
-      // Pages under no version subdirectory are the current docs ("current").
-      var verLabel = '';
+      // Current-version pages have no version subdirectory, so no badge.
       var verMatch = h.page.url.match(/\/(v\d+(?:\.\d+)?)\//);
-      verLabel = verMatch ? verMatch[1] : 'current';
+      var verBadge = verMatch
+        ? ' <span class="gcam-search-version">' + escapeHtml(verMatch[1]) + '</span>'
+        : '';
       html += '<li><a href="' + escapeHtml(href) + '">'
         + '<div class="gcam-search-title">' + escapeHtml(h.page.title)
-        + ' <span class="gcam-search-version">' + escapeHtml(verLabel) + '</span>'
+        + verBadge
         + ' <span class="gcam-search-count">' + h.count + '</span></div>'
         + (snip ? '<div class="gcam-search-snippet">' + snip + '</div>' : '')
         + '</a></li>';

--- a/search.json
+++ b/search.json
@@ -1,0 +1,12 @@
+---
+layout: null
+---
+[
+  {% for page in site.pages %}{% if page.title and page.url contains '.html' and page.url != '/index.html' %}
+  {
+    "title": {{ page.title | jsonify }},
+    "url": "{{ page.url | relative_url }}",
+    "content": {{ page.content | strip_html | strip_newlines | jsonify }}
+  }{% unless forloop.last %},{% endunless %}
+  {% endif %}{% endfor %}
+]

--- a/search.json
+++ b/search.json
@@ -1,12 +1,13 @@
 ---
 layout: null
 ---
+{%- assign pages = site.pages | where_exp: "p", "p.title" | where_exp: "p", "p.url contains '.html'" | where_exp: "p", "p.url != '/index.html'" -%}
 [
-  {% for page in site.pages %}{% if page.title and page.url contains '.html' and page.url != '/index.html' %}
+{%- for page in pages -%}
   {
     "title": {{ page.title | jsonify }},
     "url": "{{ page.url | relative_url }}",
     "content": {{ page.content | strip_html | strip_newlines | jsonify }}
-  }{% unless forloop.last %},{% endunless %}
-  {% endif %}{% endfor %}
+  }{%- unless forloop.last -%},{%- endunless -%}
+{%- endfor -%}
 ]

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -386,27 +386,104 @@ footer p + p {
   border-color: #069;
   box-shadow: 0 0 0 2px rgba(0, 102, 153, 0.15);
 }
+/* Reset all inherited header styles on the search overlay */
 #gcam-search-overlay {
   position: absolute !important;
-  top: calc(100% + 4px) !important;
+  top: calc(100% + 6px) !important;
   left: 0 !important;
-  right: 0 !important;
-  min-width: 320px;
+  right: auto !important;
+  width: 460px !important;
+  max-width: calc(100vw - 60px) !important;
+  height: auto !important;
   z-index: 99999 !important;
   background: #fff !important;
-  border: 2px solid #069 !important;
-  border-radius: 6px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.35);
-  max-height: 500px;
-  overflow-y: auto;
-  text-align: left;
-  display: block;
+  border: 1px solid #b2d2e1 !important;
+  border-radius: 6px !important;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.18) !important;
+  max-height: 60vh !important;
+  overflow-y: auto !important;
+  text-align: left !important;
+  padding: 0 !important;
 }
 #gcam-search-overlay[hidden] { display: none !important; }
-#gcam-search-overlay ul {
+#gcam-search-overlay::before { display: none !important; }
+#gcam-search-overlay ul,
+#gcam-search-results {
   list-style: none !important;
   margin: 0 !important;
   padding: 4px 0 !important;
+  position: static !important;
+  background: none !important;
+  border-radius: 0 !important;
+  box-shadow: none !important;
+  height: auto !important;
+  width: 100% !important;
+  right: auto !important;
+  top: auto !important;
+}
+#gcam-search-results::before { display: none !important; }
+#gcam-search-results li {
+  list-style: none !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  width: auto !important;
+  float: none !important;
+  border: none !important;
+  height: auto !important;
+  background: none !important;
+}
+#gcam-search-results li a {
+  display: block !important;
+  padding: 10px 14px !important;
+  text-decoration: none !important;
+  color: #333 !important;
+  border-bottom: 1px solid #f0f0f0 !important;
+  font-size: 13px !important;
+  line-height: 1.5 !important;
+  height: auto !important;
+  text-align: left !important;
+  font-weight: 400 !important;
+  text-shadow: none !important;
+  background: none !important;
+}
+#gcam-search-results li:last-child a { border-bottom: none !important; }
+#gcam-search-results li a:hover { background: #eef6fb !important; }
+#gcam-search-results .gcam-search-title {
+  font-size: 13.5px;
+  font-weight: 700;
+  color: #069;
+  margin-bottom: 3px;
+}
+#gcam-search-results .gcam-search-count {
+  display: inline-block;
+  font-size: 10.5px;
+  font-weight: 700;
+  color: #fff;
+  background: #c44;
+  padding: 1px 6px;
+  border-radius: 9px;
+  margin-left: 6px;
+  vertical-align: middle;
+}
+#gcam-search-results .gcam-search-snippet {
+  font-size: 12px;
+  color: #555;
+  line-height: 1.45;
+  font-style: normal;
+}
+#gcam-search-results .gcam-search-snippet mark {
+  background: #ffe680;
+  color: inherit;
+  padding: 0 2px;
+  border-radius: 2px;
+  font-weight: 600;
+}
+#gcam-search-results .gcam-search-empty {
+  padding: 14px;
+  color: #888;
+  font-size: 13px;
+  text-align: center;
+  font-style: italic;
 }
 #gcam-search-results {
   list-style: none;

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -391,14 +391,16 @@ footer p + p {
   top: calc(100% + 4px);
   left: 0;
   right: 0;
-  z-index: 100;
+  z-index: 9999;
   background: #fff;
   border: 1px solid #ccc;
   border-radius: 6px;
-  box-shadow: 0 6px 16px rgba(0,0,0,0.15);
-  max-height: 420px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  max-height: 500px;
   overflow-y: auto;
+  text-align: left;
 }
+#gcam-search-overlay[hidden] { display: none; }
 #gcam-search-results {
   list-style: none;
   margin: 0;

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -485,6 +485,20 @@ footer p + p {
   text-align: center;
   font-style: italic;
 }
+
+/* In-page highlights for when arriving via ?q=... */
+mark.gcam-page-highlight {
+  background: #ffe680;
+  color: inherit;
+  padding: 0 2px;
+  border-radius: 2px;
+}
+mark.gcam-page-highlight-first {
+  background: #ff9b3d;
+  color: #000;
+  font-weight: 600;
+  box-shadow: 0 0 0 2px rgba(255, 155, 61, 0.4);
+}
 #gcam-search-results {
   list-style: none;
   margin: 0;

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -339,14 +339,26 @@ footer p + p {
 }
 
 /* ---- Documentation search ---- */
+.gcam-nav-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.gcam-nav-row .nav {
+  margin: 0;
+  flex: 1 1 auto;
+}
 .gcam-search-box {
   position: relative;
-  margin: 8px 0 10px;
+  flex: 0 0 260px;
+  max-width: 260px;
 }
 #gcam-search-input {
   width: 100%;
-  padding: 7px 10px;
-  font-size: 14px;
+  padding: 6px 10px;
+  font-size: 13px;
   border: 1px solid #b2d2e1;
   border-radius: 4px;
   background: #fff;

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -338,6 +338,85 @@ footer p + p {
   float: right;
 }
 
+/* ---- Documentation search ---- */
+.gcam-search-box {
+  position: relative;
+  margin: 8px 0 10px;
+}
+#gcam-search-input {
+  width: 100%;
+  padding: 7px 10px;
+  font-size: 14px;
+  border: 1px solid #b2d2e1;
+  border-radius: 4px;
+  background: #fff;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+#gcam-search-input:focus {
+  outline: none;
+  border-color: #069;
+  box-shadow: 0 0 0 2px rgba(0, 102, 153, 0.15);
+}
+#gcam-search-overlay {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-top: none;
+  border-radius: 0 0 6px 6px;
+  box-shadow: 0 6px 16px rgba(0,0,0,0.15);
+  max-height: 420px;
+  overflow-y: auto;
+}
+#gcam-search-results {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+}
+#gcam-search-results li a {
+  display: block;
+  padding: 8px 12px;
+  text-decoration: none;
+  color: #333;
+  border-bottom: 1px solid #f0f0f0;
+}
+#gcam-search-results li a:hover {
+  background: #e8f4fc;
+}
+.gcam-search-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #069;
+}
+.gcam-search-count {
+  font-size: 11px;
+  font-weight: 700;
+  color: #c44;
+  margin-left: 4px;
+}
+.gcam-search-snippet {
+  font-size: 12px;
+  color: #666;
+  margin-top: 2px;
+  line-height: 1.4;
+}
+.gcam-search-snippet mark {
+  background: #ffe680;
+  color: inherit;
+  padding: 0 1px;
+  border-radius: 2px;
+}
+.gcam-search-empty {
+  padding: 12px;
+  color: #999;
+  font-size: 13px;
+  text-align: center;
+}
+
 @media print, screen and (max-width: 740px) {
   body {
     padding: 0;

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -465,6 +465,19 @@ footer p + p {
   margin-left: 6px;
   vertical-align: middle;
 }
+#gcam-search-results .gcam-search-version {
+  display: inline-block;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: #555;
+  background: #e3eaf0;
+  padding: 1px 6px;
+  border-radius: 9px;
+  margin-left: 6px;
+  vertical-align: middle;
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
 #gcam-search-results .gcam-search-snippet {
   font-size: 12px;
   color: #555;

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -352,11 +352,13 @@ footer p + p {
 }
 .gcam-search-box {
   position: relative;
-  flex: 0 0 260px;
-  max-width: 260px;
+  flex: 0 0 320px;
+  max-width: 320px;
+  display: flex;
+  gap: 4px;
 }
 #gcam-search-input {
-  width: 100%;
+  flex: 1;
   padding: 6px 10px;
   font-size: 13px;
   border: 1px solid #b2d2e1;
@@ -365,6 +367,20 @@ footer p + p {
   font-family: inherit;
   box-sizing: border-box;
 }
+#gcam-search-button {
+  padding: 6px 14px;
+  font-size: 13px;
+  font-family: inherit;
+  font-weight: 700;
+  color: #fff;
+  background: #069;
+  border: 1px solid #069;
+  border-radius: 4px;
+  cursor: pointer;
+}
+#gcam-search-button:hover {
+  background: #047;
+}
 #gcam-search-input:focus {
   outline: none;
   border-color: #069;
@@ -372,14 +388,13 @@ footer p + p {
 }
 #gcam-search-overlay {
   position: absolute;
-  top: 100%;
+  top: calc(100% + 4px);
   left: 0;
   right: 0;
   z-index: 100;
   background: #fff;
   border: 1px solid #ccc;
-  border-top: none;
-  border-radius: 0 0 6px 6px;
+  border-radius: 6px;
   box-shadow: 0 6px 16px rgba(0,0,0,0.15);
   max-height: 420px;
   overflow-y: auto;

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -387,20 +387,27 @@ footer p + p {
   box-shadow: 0 0 0 2px rgba(0, 102, 153, 0.15);
 }
 #gcam-search-overlay {
-  position: absolute;
-  top: calc(100% + 4px);
-  left: 0;
-  right: 0;
-  z-index: 9999;
-  background: #fff;
-  border: 1px solid #ccc;
+  position: absolute !important;
+  top: calc(100% + 4px) !important;
+  left: 0 !important;
+  right: 0 !important;
+  min-width: 320px;
+  z-index: 99999 !important;
+  background: #fff !important;
+  border: 2px solid #069 !important;
   border-radius: 6px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.25);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.35);
   max-height: 500px;
   overflow-y: auto;
   text-align: left;
+  display: block;
 }
-#gcam-search-overlay[hidden] { display: none; }
+#gcam-search-overlay[hidden] { display: none !important; }
+#gcam-search-overlay ul {
+  list-style: none !important;
+  margin: 0 !important;
+  padding: 4px 0 !important;
+}
 #gcam-search-results {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
Hi, thank you for maintaining such thorough documentation for GCAM. It has been a huge help.

One thing I kept running into is that the docs site has no search box, so finding a specific function or explanation usually meant visiting many pages. This PR adds a search bar to make that easier.

## Summary
- Adds a search box to the top of every documentation page.
- When a user types a query, matching pages appear in a dropdown list with a short preview of the matching text.
- Pages from older archived versions (`vX.Y`) are labeled with a version badge and sorted below current docs so they do not get in the way.
- Clicking a result opens that page, scrolls to the first match.
- Everything runs in the browser with plain JavaScript, no extra build steps or external libraries needed.
- The search index rebuilds automatically on every Jekyll build, so no manual updates are needed when new pages or versions are added.

I built this on my fork so you can see how it works: https://jiheunha.github.io/gcam-doc/

Thank you!